### PR TITLE
Revert "Update dependency Jinja2 to v3.1.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ mkdocs-material==9.5.49
 mike==2.1.3
 
 # https://github.com/squidfunk/mkdocs-material/issues/3085#issuecomment-933373590
-Jinja2==3.1.5
+Jinja2==3.1.4


### PR DESCRIPTION
Reverts genestack/user-docs#79 because of build fail:
`No matching distribution found for Jinja2==3.1.5`