### PR TITLE
ODM-12455: Adding technical fields by default

### DIFF
--- a/docs/tools/odm-sdk/terminal/templates/Default_ODM_Template.json
+++ b/docs/tools/odm-sdk/terminal/templates/Default_ODM_Template.json
@@ -3,14 +3,6 @@
     "dataType": "study",
     "isRequired": true,
     "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "name": "genestack:accession",
-    "isReadOnly": true,
-    "description": "Genestack-generated accession"
-  },
-  {
-    "dataType": "study",
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
     "name": "Study Source",
     "isReadOnly": false
   },
@@ -88,21 +80,6 @@
     "isReadOnly": false
   },
   {
-    "dataType": "genestack:transcriptomicsParent",
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "name": "genestack:accession",
-    "isReadOnly": true
-  },
-  {
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "dataType": "genestack:transcriptomicsParent",
-    "name": "Data Class",
-    "isReadOnly": true,
-    "description": "A mandatory field specifying the exact type of data you have uploaded. Please do not remove this attribute."
-  },
-  {
     "dictionaryName": "Sequencing Platforms",
     "dataType": "genestack:transcriptomicsParent",
     "isRequired": false,
@@ -175,45 +152,7 @@
     "isReadOnly": false
   },
   {
-    "isRequired": false,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "dataType": "genestack:transcriptomicsParent",
-    "name": "Features (string)",
-    "isReadOnly": true,
-    "description": "If your dataset contains multiple columns for feature, this parameter lists columns with text content (e.g., Gene Name). Please do not remove this attribute."
-  },
-  {
-    "isRequired": false,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "dataType": "genestack:transcriptomicsParent",
-    "name": "Features (numeric)",
-    "isReadOnly": true,
-    "description": "If your dataset contains multiple columns for feature, this parameter lists columns with numeric content (e.g., Retention Time, M/Z ratio). Please do not remove this attribute."
-  },
-  {
-    "isRequired": false,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "dataType": "genestack:transcriptomicsParent",
-    "name": "Values (numeric)",
-    "isReadOnly": true,
-    "description": "If your dataset contains multiple measurement or value types for each item (like a sample, library, or preparation), this parameter lists these (e.g. Intensity, Fold Change, p-value). Please do not remove this attribute."
-  },
-  {
-    "dataType": "genestack:facsParent",
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "name": "genestack:accession",
-    "isReadOnly": true
-  },
-  {
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "dataType": "genestack:facsParent",
-    "name": "Data Class",
-    "isReadOnly": true,
-    "description": "A mandatory field specifying the exact type of data you have uploaded. Please do not remove this attribute."
-  },
-  {
+    "dictionaryName": "Sequencing Platforms",
     "dataType": "genestack:facsParent",
     "isRequired": false,
     "metainfoType": "com.genestack.api.metainfo.StringValue",
@@ -268,14 +207,6 @@
     "metainfoType": "com.genestack.api.metainfo.StringValue",
     "name": "Name",
     "isReadOnly": false
-  },
-  {
-    "dataType": "genestack:sampleObject",
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "name": "genestack:accession",
-    "isReadOnly": true,
-    "description": "Genestack-generated accession"
   },
   {
     "dataType": "genestack:sampleObject",
@@ -400,21 +331,6 @@
     "isReadOnly": false
   },
   {
-    "dataType": "genestack:genomicsParent",
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "name": "genestack:accession",
-    "isReadOnly": true
-  },
-  {
-    "isRequired": true,
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "dataType": "genestack:genomicsParent",
-    "name": "Data Class",
-    "isReadOnly": true,
-    "description": "A mandatory field specifying the exact type of data you have uploaded. Please do not remove this attribute."
-  },
-  {
     "dictionaryName": "Sequencing Platforms",
     "dataType": "genestack:genomicsParent",
     "isRequired": false,
@@ -477,13 +393,6 @@
     "metainfoType": "com.genestack.api.metainfo.StringValue",
     "name": "Name",
     "isReadOnly": false
-  },
-  {
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "isRequired": true,
-    "dataType": "genestack:libraryObject",
-    "name": "genestack:accession",
-    "isReadOnly": true
   },
   {
     "metainfoType":  "com.genestack.api.metainfo.StringValue",
@@ -599,13 +508,6 @@
     "dataType": "genestack:libraryObject",
     "name": "Dose",
     "isReadOnly": false
-  },
-  {
-    "metainfoType": "com.genestack.api.metainfo.StringValue",
-    "isRequired": true,
-    "dataType": "genestack:preparationObject",
-    "name": "genestack:accession",
-    "isReadOnly": true
   },
   {
     "metainfoType":  "com.genestack.api.metainfo.StringValue",

--- a/docs/tools/odm-sdk/terminal/templates/create-or-update-template.md
+++ b/docs/tools/odm-sdk/terminal/templates/create-or-update-template.md
@@ -74,17 +74,11 @@ The template json file is validated in ODM against an internal schema: [template
 
     Expression (both Transcriptomics and Proteomics): `dataType = "genestack:transcriptomicsParent"`
 
-3. The `Accession` property is mandatory for each type of object. The following values should be set for each dataType section:
+3. Some technical fields will be automatically added for certain object types.
+    For example, `"genestack:accession"` will be added for all object types, and
+    `"Data Class"` will be added for transcriptomics, genomics, and facs parents.
 
-    ```text
-    name = "genestack:accession",
-    metainfoType = "com.genestack.api.metainfo.StringValue",
-    isRequired = true,
-    isReadOnly = true
-    ```
-
-    It is recommended to include properties having `isRequired = true` into the template file. Please also check out
-    the `description` property attribute: some properties might be required for certain functionality.
+    It is recommended to include properties having `isRequired = true` in the template file.
 
 4. The values accepted for each metadata attribute are given by the `metainfoType` key, and must be one of the following values:
 


### PR DESCRIPTION
- Removing technical fields, added by default: genestack:accession, Data Class, Features (string), Features (numeric), Values (numeric).
- Changing the description in the doc.
- Fixing minor issue with Experimental Platform.