### PR TITLE
Fixes for Attachment Transformation article

### DIFF
--- a/docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+++ b/docs/user-guide/doc-odm-user-guide/attachment-transformation.md
@@ -213,6 +213,6 @@ As the result new Sample metadata group was created in ODM:
 
 ![Sample-group](../doc-odm-user-guide/doc-odm-user-guide/images/attachments-transformation-samples.png)
 
-To retrieve transformation job logs simply use jod id in POST `transformations/jobs/{id}/logs` endpoint.
+To retrieve transformation job logs simply use job id in POST `transformations/jobs/{id}/logs` endpoint.
 
 !!! danger "Transformation job logs are stored for 2 weeks as default in the system"

--- a/docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+++ b/docs/user-guide/doc-odm-user-guide/attachment-transformation.md
@@ -12,8 +12,12 @@ e.g. Samples, Libraries, Preparations, Cell metadata, Expression, Variants, etc.
 ![Diagram](../doc-odm-user-guide/doc-odm-user-guide/images/attachments-transformation-diagram.png)
 
 ## Get the list of available images
+
 Currently ODM has default image called `metadata-basic`.
 This image allows user to transform `CSV` files into `TSV` to create Sample group.
+
+!!! danger "`metadata-basic` transformation is introduced just for testing purpose"
+    
 
 To get the list of available images via API go to `processorsController` Swagger definition of endpoints and use 
 GET `transformations/images`. Endpoint response example:
@@ -208,3 +212,7 @@ is placed.
 As the result new Sample metadata group was created in ODM:
 
 ![Sample-group](../doc-odm-user-guide/doc-odm-user-guide/images/attachments-transformation-samples.png)
+
+To retrieve transformation job logs simply use jod id in POST `transformations/jobs/{id}/logs` endpoint.
+
+!!! danger "Transformation job logs are stored for 2 weeks as default in the system"


### PR DESCRIPTION
Info about metadata basic (as transformations for testing) 

- <img width="1023" height="203" alt="image" src="https://github.com/user-attachments/assets/58aa13fc-1b88-4170-98e7-c3abcbc286ac" />

and logs were added. 

- <img width="1024" height="118" alt="image" src="https://github.com/user-attachments/assets/cf39934b-2459-43cd-be70-eca8f322e56e" />
