### PR TITLE
Add processors controller related user docs for review

### DIFF
--- a/docs-rework/odm-api/contribute/transformations/about-processors-controller.md
+++ b/docs-rework/odm-api/contribute/transformations/about-processors-controller.md
@@ -1,0 +1,60 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/about-sc-hdf5-transformations.md
+    lines: [64, 72]
+  - path: docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+    lines: [1, 13]
+diataxis: explanation
+tab: odm-api
+task: task-091
+tickets:
+  - ODM-13233
+  - ODM-13292
+  - ODM-13324
+---
+
+# About the Processors Controller
+
+A transformation takes an attached input file and turns its contents into ODM objects. Some transformations produce indexable metadata — for example, ODM cannot index a CSV file directly as a source of metadata, but the `metadata-basic` transformation converts it into TSV-based metadata objects that ODM can index. Others turn raw data into structured ODM objects — for example, the `hdf5-cells` transformation converts single-cell HDF5 (H5AD/H5) files into ODM Cell Groups and Expression Groups. Either way, a transformation bridges the gap between the file you have and the ODM objects you need.
+
+Transformations are managed through the ODM Processors Controller API, which is built on three related components: configurations, images, and jobs.
+
+These three map onto a simple idea: an image is *what processing to do*, a configuration is *how to tune it*, and a job is *doing it once, against specific files*. The same image and configuration can drive many independent jobs.
+
+## Transformation configurations
+
+Transformation configurations are JSON documents (a structured, text-based settings format) that define how an input file should be processed — including the input format, metadata extraction rules, and curation logic. Configurations are stored centrally and identified by an integer ID. The same configuration can be reused across multiple input files that share the same structure, and configurations can be created, retrieved, and updated independently of any particular run. Configurations are versioned: updating a configuration does not overwrite it but archives the current state as a previous version and increments the active version. Earlier versions remain retrievable, so a job can always be audited or re-run with the exact parameters it used.
+
+## Transformation images
+
+Transformation images are versioned container images (self-contained, ready-to-run packages of the processing software) that run the processing logic. Available image versions can be queried through the API. Each image handles a specific input/output format pair: for example, `metadata-basic` converts CSV files to TSV-based metadata objects (samples, libraries, preparations, cell metadata, expression, or variants); `hdf5-cells` converts H5AD or H5 single-cell files into ODM Cell Groups, Expression Groups, and associated metadata. When starting a job you can specify either `latest` or a specific release tag.
+
+## Transformation jobs
+
+Transformation jobs are the execution records. A job combines an image and one or more input file accessions and a configuration, then runs the transformation and produces output plus a processing log. Jobs are independent — the same input file can be submitted again with a different configuration or image without affecting previous runs.
+
+Job operations respect ODM's existing permissions: you can only act on a job if you have access to the studies its input attachments belong to, and creating or managing jobs requires the appropriate curation permissions. See the [API reference](api-reference.md) for the exact rules.
+
+A job is not where your results are stored. As it runs, the transformation writes its output into ODM as ordinary objects, so once the job finishes those results are part of your ODM data like anything else.
+
+When a job finishes it stops running, and the resources that were processing it are released — nothing keeps running in the background. What stays behind is the job's record: its final status and full logs. These are kept indefinitely, with no expiry, and are never deleted. You retrieve them through the same API endpoints whether the job is still running or finished long ago, so from your side nothing about fetching a job's status or logs changes once it is done.
+
+You can cancel a job while it is still running; it is then recorded in the terminal `CANCELLED` state, distinct from a failure. Its final status and logs remain available like any other job's.
+
+## Dry-run mode
+
+Transformations can be run in dry-run mode by setting `dry_run: true`. A dry run validates the configuration and input without writing any objects to ODM, which makes it the safest way to iterate on a configuration before committing results. For the steps to run a job in dry-run mode, see [How to run a transformation](how-to-run-a-transformation.md).
+
+<!-- TODO: Confirm which transformation images actually implement dry-run (validate-without-write). The flag is accepted for all jobs, but honoring it is image-specific. If not universal, scope this wording (e.g. to single-cell). -->
+
+## Transformation logs
+
+Each job produces a log recording processing steps, warnings, errors, the source file name and accession, and the accessions of any ODM objects it created. Logs are retained permanently and are always retrievable through the API: the logs endpoint returns the live log while the job runs and the archived log once it has finished, transparently. A finished job's log is never unavailable. Separately, the log is also uploaded into ODM as an attachment on the owning study, so it sits alongside the job's other generated files; this attachment is an additional copy and is not what keeps the log available.
+
+## Where to start
+
+- For the transformation API endpoints, see the [Processors Controller API reference](api-reference.md).
+- For the step-by-step workflow applicable to any transformation type, see [How to run a transformation](how-to-run-a-transformation.md).
+- For managing configurations, see [How to manage transformation configurations](manage-configurations.md).
+- For the single-cell HDF5 use case, start with [About single-cell HDF5 transformations](single-cell/about-single-cell-transformations.md).
+- For the CSV-to-TSV use case, see [How to transform a CSV file to a Sample group](csv-to-tsv/how-to-transform-csv-to-tsv.md).

--- a/docs-rework/odm-api/contribute/transformations/api-reference.md
+++ b/docs-rework/odm-api/contribute/transformations/api-reference.md
@@ -1,0 +1,360 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/api-reference.md
+    lines: [1, 256]
+diataxis: reference
+tab: odm-api
+task: task-094
+tickets:
+  - ODM-13233
+  - ODM-13239
+  - ODM-13243
+  - ODM-13292
+  - ODM-13304
+  - ODM-13324
+  - ODM-13326
+---
+
+# Processors Controller API reference
+
+This reference describes the Processors Controller API endpoints used to manage transformation configurations, list images, and submit, monitor, and inspect transformation jobs. The endpoints are use-case-agnostic — they apply to all transformation types.
+
+For the conceptual model behind these endpoints, see [About the Processors Controller](about-processors-controller.md). For the step-by-step workflow, see [How to run a transformation](how-to-run-a-transformation.md). For per-image `data` field schemas, see [Available images reference](available-images-reference.md) and [Single-cell HDF5 configuration reference](single-cell/configuration-reference.md).
+
+---
+
+## Quick reference
+
+| Operation | Method | Endpoint |
+|---|---|---|
+| List configurations | `GET` | `/api/v1/transformations/configurations` |
+| Get a configuration | `GET` | `/api/v1/transformations/configurations/{id}` |
+| Create a configuration | `POST` | `/api/v1/transformations/configurations` |
+| Update a configuration (creates a new version) | `PUT` | `/api/v1/transformations/configurations/{id}` |
+| List configuration versions | `GET` | `/api/v1/transformations/configurations/{id}/versions` |
+| Get a configuration version | `GET` | `/api/v1/transformations/configurations/{id}/versions/{version}` |
+| List images | `GET` | `/api/v1/transformations/images` |
+| Submit a job | `POST` | `/api/v1/transformations/jobs` |
+| List jobs | `GET` | `/api/v1/transformations/jobs` |
+| Get job status | `GET` | `/api/v1/transformations/jobs/{id}` |
+| Cancel a job | `POST` | `/api/v1/transformations/jobs/{id}/cancel` |
+| Retrieve job logs | `POST` | `/api/v1/transformations/jobs/{id}/logs` |
+
+---
+
+## Pagination
+
+All list (collection) endpoints return a paginated envelope rather than a bare array, and accept `limit` and `offset` query parameters. The paginated endpoints are:
+
+- `GET /api/v1/transformations/configurations`
+- `GET /api/v1/transformations/configurations/{id}/versions`
+- `GET /api/v1/transformations/jobs`
+- `GET /api/v1/transformations/images`
+
+**Query parameters:**
+
+| Parameter | Type | Default | Constraints | Description |
+|---|---|---|---|---|
+| `limit` | integer | 100 | min 1, max 1000 | Maximum number of items to return. |
+| `offset` | integer | 0 | min 0 | Number of items to skip from the start of the list. |
+
+Both parameters are optional; the defaults apply when omitted.
+
+**Response envelope:**
+
+```json
+{
+  "items": [ ... ],
+  "total": 137,
+  "limit": 100,
+  "offset": 0
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `items` | array | The page of results. Always an array — empty rather than `null`. |
+| `total` | integer | Total number of items available before pagination. |
+| `limit` | integer | The effective limit applied to this page. |
+| `offset` | integer | The effective offset applied to this page. |
+
+> **[Breaking change]** List endpoints previously returned a bare JSON array; they now return the paginated envelope above, with results under `items`.
+
+---
+
+## Transformation configurations
+
+A transformation configuration is a stored JSON document that defines how a source file is processed. Configurations are reusable across jobs and versioned. For the conceptual model, see [About the Processors Controller](about-processors-controller.md); versioning behaviour is described under [Update a configuration](#update-a-configuration) below.
+
+### List configurations
+
+```
+GET /api/v1/transformations/configurations
+```
+
+Returns a [paginated envelope](#pagination); each `items` entry is the latest version of a configuration, including its full `data`. Each object includes:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | integer | Unique identifier for the configuration |
+| `version` | integer | Version number returned (the latest version of the configuration) |
+| `name` | string | Human-readable name |
+| `description` | string | Human-readable description |
+| `data` | object | The full processing specification (image-specific) |
+| `create_time` | string | Timestamp of when the configuration was created (e.g. `2026-04-14T15:27:04Z`) |
+
+### Get a configuration
+
+```
+GET /api/v1/transformations/configurations/{id}
+```
+
+Returns the latest version of the configuration with the given `id`, including the `data` field with all processing rules. The response includes a `create_time` timestamp recording when the configuration was created, and a `version` field alongside `id` identifying which version was returned. To retrieve an earlier version, use the version endpoints below.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | integer | ID of the configuration to retrieve |
+
+### Create a configuration
+
+```
+POST /api/v1/transformations/configurations
+```
+
+Creates a new transformation configuration and returns its assigned `id`.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | Human-readable name (optional but recommended) |
+| `description` | string | No | Human-readable description (optional but recommended) |
+| `data` | object | Yes | The processing specification. The schema is image-specific — see [Available images reference](available-images-reference.md). |
+
+**Response:** A reference object containing the `id` assigned to the new configuration (and its `version`, which is `1` for a new configuration). This `id` is required when submitting a job.
+
+### Update a configuration
+
+```
+PUT /api/v1/transformations/configurations/{id}
+```
+
+Creates a new version of the configuration at the given `id`. The current state is archived as a previous version and the active version is incremented; the configuration is not overwritten. Earlier versions remain retrievable through the version endpoints below.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | integer | ID of the configuration to update |
+
+**Request body:** Same structure as `POST /api/v1/transformations/configurations`.
+
+### List configuration versions
+
+```
+GET /api/v1/transformations/configurations/{id}/versions
+```
+
+Returns a [paginated envelope](#pagination) whose `items` are the available versions of the configuration with the given `id`.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | integer | ID of the configuration whose versions to list |
+
+### Get a configuration version
+
+```
+GET /api/v1/transformations/configurations/{id}/versions/{version}
+```
+
+Returns a single configuration version.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | integer | ID of the configuration |
+| `version` | integer | Version to retrieve |
+
+---
+
+## Transformation images
+
+A transformation image is a versioned, containerised processing environment that executes the transformation logic for a specific input format, and is managed separately from configurations.
+
+### List images
+
+```
+GET /api/v1/transformations/images
+```
+
+Returns a [paginated envelope](#pagination) whose `items` are the available image objects.
+
+**Response fields per image:**
+
+| Field | Description |
+|---|---|
+| `name` | Identifier used when referencing the image in a job (e.g. `"hdf5-cells"`) |
+| `version` | Version tag (e.g. `"latest"` or a specific release tag such as `"0.0.7"`) |
+| `description` | Human-readable description of the image's purpose |
+| `input_formats` | File formats accepted as input |
+| `output_formats` | File formats produced as output (one of: `attachments`, `cells`, `expressions`, `flow-cytometries`, `libraries`, `preparations`, `samples`, `studies`, `variants`) |
+| `default_volume_size` | Default scratch volume size used when a job omits `volume_size` (Kubernetes quantity string, e.g. `"30Gi"`) |
+| `default_memory_size` | Default memory limit used when a job omits `memory_size` (Kubernetes quantity string, e.g. `"512Mi"`) |
+
+---
+
+## Transformation jobs
+
+A transformation job binds a configuration and an image to one or more input file accessions and executes the processing pipeline, producing an execution log and, on a full (non-dry-run) run, creating or updating ODM objects.
+
+Every job is retained permanently. Once a job finishes — or is cancelled — its final status and full logs are kept in long-term storage and stay available through these endpoints, while its compute resources are freed. Jobs cannot be deleted.
+
+### Access and permissions
+
+Every transformation job endpoint enforces an access check against the studies that contain the attachments in the job's `input_accessions`. Every study that contains a listed attachment must be **shared with you**. If the attachments span multiple studies, all of those studies must be shared with you.
+
+If any accession is not found, or belongs to a study that is not shared with you, the request is rejected with a generic message — `Item not found or insufficient permission` — that does not reveal whether the item exists.
+
+Creating or cancelling a job additionally requires **Curator group membership**. Jobs cannot be deleted; they are retained permanently.
+
+On submission (`POST /api/v1/transformations/jobs`), the accessions to check are taken from the request body. For the other endpoints, ODM retrieves the job's `input_accessions` (via `GET /api/v1/transformations/jobs/{id}`) and checks that the studies that contain them are shared with you.
+
+For how studies are shared, see [Sharing and ownership](../../../overview/access-control/sharing-and-ownership.md); for the Curator group, see [Groups and roles](../../../overview/access-control/groups-and-roles.md).
+
+| Endpoint | Required access |
+|---|---|
+| `GET /api/v1/transformations/jobs` | Every study containing a listed input attachment is shared with you. Results are filtered to the jobs you can access. |
+| `GET /api/v1/transformations/jobs/{id}` | Every study containing a listed input attachment is shared with you |
+| `POST /api/v1/transformations/jobs/{id}/logs` | Every study containing a listed input attachment is shared with you |
+| `POST /api/v1/transformations/jobs` | Curator group membership + every study containing a listed input attachment is shared with you |
+| `POST /api/v1/transformations/jobs/{id}/cancel` | Curator group membership + every study containing a listed input attachment is shared with you |
+
+### Submit a job
+
+```
+POST /api/v1/transformations/jobs
+```
+
+Creates and submits a new transformation job. The response includes the `id` of the created job.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `configuration_reference` | object | No | The transformation configuration to use. Contains `id` (integer, required within the object) and `version` (integer, optional). Optional at the API level, though most images require a configuration. If omitted, the latest version is used (see below). |
+| `dry_run` | boolean | No | `true` to simulate without writing data; `false` (the default) for a full run |
+| `image_reference` | object | Yes | Specifies the image to use. Contains `name` (string) and `version` (string). |
+| `input_accessions` | array of strings | Yes | ODM accessions of the input files to process (at least one) |
+| `volume_size` | string | No | Scratch volume size as a Kubernetes quantity string (e.g. `"30Gi"`). If omitted, the image's `default_volume_size` is used, falling back to `"30Gi"`. |
+| `memory_size` | string | No | Memory limit as a Kubernetes quantity string (e.g. `"512Mi"`). If omitted, the image's `default_memory_size` is used, falling back to `"512Mi"`. |
+
+**`configuration_reference` fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | integer | Yes | ID of the transformation configuration |
+| `version` | integer | No | Specific configuration version to run. If omitted, the latest version is used. |
+
+The job records the configuration version it executed against, so the audit trail remains intact even if the configuration is updated later.
+
+> **[Subject to change — ODM-13233]** The exact name and shape of the job-submission `configuration_reference` field are not yet finalized. This block documents the proposed schema; verify against the released API before relying on it.
+
+**`image_reference` fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Image name (e.g. `"hdf5-cells"` or `"metadata-basic"`) |
+| `version` | string | Version tag. Use `"latest"` or a specific release tag (e.g. `"0.0.7"`). |
+
+For `volume_size` sizing guidance — including the per-format recommendations and why 10x H5 files need extra scratch space — see [Job resource parameters reference](resource-parameters-reference.md). For per-image guidance, see [Available images reference](available-images-reference.md).
+
+### List jobs
+
+```
+GET /api/v1/transformations/jobs
+```
+
+Returns a [paginated envelope](#pagination). Each object in `items` includes the same fields as the single-job response (see [Get job status](#get-job-status)), including `create_time` and `end_time`. Results are filtered to the jobs whose input attachments you can access; see [Access and permissions](#access-and-permissions).
+
+> **Note — pagination counts and access filtering:** The service paginates *before* per-user access filtering is applied, so the pagination metadata describes the unfiltered dataset, not what you can see. `items` is the access-filtered subset of the requested page, but `total`, `limit`, and `offset` are passed through unmodified and reflect all jobs matching the query — including jobs you cannot access. As a result, `total` can overcount, a page may return fewer than `limit` items (even zero) while accessible jobs still exist on later pages, and a page count derived as `ceil(total / limit)` will be wrong. Do not assume `items.length == limit` on a full page, nor that `total` equals the number of jobs you can access.
+
+### Get job status
+
+```
+GET /api/v1/transformations/jobs/{id}
+```
+
+Returns the job object, including the current `status.state`.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | integer | ID of the job to query |
+
+**`status.state` values:**
+
+| State | Meaning |
+|---|---|
+| `PENDING` | Job accepted; its processing environment has not started being set up yet |
+| `WAITING` | Processing environment is starting up, typically while the transformation image is downloaded; the transformation has not begun |
+| `RUNNING` | Transformation is actively processing the input |
+| `DONE` | Finished successfully |
+| `FAILED` | Finished with an error (may carry a reason such as `OOMKilled`) |
+| `CANCELLED` | Cancelled by a user; a terminal state distinct from `FAILED`, carrying no reason or description |
+| `UNKNOWN` | The job's state cannot currently be determined |
+
+For a normal run the order is `PENDING` → `WAITING` → `RUNNING` → `DONE` (or `FAILED`).
+
+**`archived`:**
+
+A required boolean indicating whether the job has finished and its final status and full logs have been moved to permanent storage (and its compute resources freed). Archived jobs can no longer be cancelled, but their status and logs remain available. `archived` is `false` while a job is running and flips to `true` a short time after it finishes — or immediately when it is cancelled. This field is present on both this response and [List jobs](#list-jobs).
+
+**`end_time`:**
+
+The job object includes an `end_time` timestamp, set automatically when the job reaches a terminal state (`DONE`, `FAILED`, or `CANCELLED`). While the job is in a non-terminal state (`PENDING`, `WAITING`, `RUNNING`, or `UNKNOWN`), `end_time` is omitted. Pair it with `create_time` to calculate how long a job ran. The field is populated for existing jobs as well as new ones.
+
+### Retrieve job logs
+
+```
+POST /api/v1/transformations/jobs/{id}/logs
+```
+
+Returns the log records for the specified job. Logs are always available, including for finished and archived jobs: while the job runs, the endpoint returns its live logs; once the job has been archived, it serves the stored logs transparently. A finished or archived job's logs are never reported as not found. The `tail_lines` option applies to both live and archived logs.
+
+Logs include:
+
+- Configuration validation messages.
+- Input file structure report (keys, data types, shapes, attribute names).
+- Warnings and errors encountered during metadata extraction and curation.
+- Linking validation results (dry-run).
+- Accessions of ODM objects created or updated (full run).
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | integer | ID of the job whose logs to retrieve |
+
+### Cancel a job
+
+```
+POST /api/v1/transformations/jobs/{id}/cancel
+```
+
+Cancels a running job. Cancellation terminates the job immediately, records it in the terminal `CANCELLED` state, and archives its final status and logs to permanent storage. The endpoint takes no request body and returns `204 No Content`.
+
+A job can be cancelled until it has been archived. Once archived (its compute resources freed), the endpoint returns a not-found error; its status and logs remain available.
+
+**Path parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | integer | ID of the job to cancel |
+
+Requires Curator group membership, and every study containing a listed input attachment must be shared with you. See [Access and permissions](#access-and-permissions).

--- a/docs-rework/odm-api/contribute/transformations/available-images-reference.md
+++ b/docs-rework/odm-api/contribute/transformations/available-images-reference.md
@@ -1,0 +1,84 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+    lines: [14, 73]
+  - path: docs/user-guide/doc-odm-user-guide/about-sc-hdf5-transformations.md
+    lines: [80, 89]
+  - path: docs/user-guide/doc-odm-user-guide/api-reference.md
+    lines: [177, 185]
+diataxis: reference
+tab: odm-api
+task: task-095
+---
+
+# Available transformation images reference
+
+Each transformation image handles a specific input/output format pair. Use `GET /api/v1/transformations/images` to retrieve the current list of available images and their versions at runtime.
+
+---
+
+## metadata-basic
+
+> **Note:** The `metadata-basic` image was introduced as an example transformation.
+
+**Description:** Basic converter from attachment to metadata.
+
+**Input formats:** `csv`
+
+**Output formats:** `samples`
+
+**Default memory:** `256Mi`
+
+**Default volume:** `5Gi`
+
+**Available versions:** `latest`
+
+**Use case:** Converts a CSV file attached to a study into an ODM Sample metadata group. The configuration `data` field specifies the source format and the destination entity type.
+
+**Example `data` field:**
+
+```json
+{
+  "source": { "csv": {} },
+  "destination": { "samples": {} }
+}
+```
+
+For the full how-to, see [csv-to-tsv/how-to-transform-csv-to-tsv.md](csv-to-tsv/how-to-transform-csv-to-tsv.md).
+
+---
+
+## hdf5-cells
+
+**Description:** Import single-cell data and metadata from HDF5 format to ODM.
+
+**Input formats:** H5AD (AnnData), 10x Genomics H5 (converted internally to H5AD before processing), Legacy 10x Genomics H5 v<3 (single-genome only; multi-genome legacy files are not supported).
+
+**Output formats:** ODM Cell Group, Expression Group, and attachments, with optional Sample, Library, and Preparation groups.
+
+**Default memory:** `5Gi`
+
+**Default volume:** `5Gi`
+
+**Available versions:** `latest`
+
+H5 files require significantly more scratch space because they are converted internally to H5AD format before processing.
+
+For the full how-to and the `data` field schema, see the [single-cell/](single-cell/) subsection.
+
+---
+
+## Version conventions
+
+- `latest` is an alias for the most recent stable version of an image. Use it for exploration and development.
+- Specific tags (for example, `0.0.7`) pin the job to a particular image version. Use them in production pipelines where reproducibility matters.
+
+---
+
+## Known limitations
+
+Only one transformation process can be run per attachment.
+
+<!-- TODO: verify — the one-transformation-per-attachment constraint is not present in transformation-images-develop/. Confirm against another source (e.g. the attachment-transformation.md migration source or the Applications layer) before treating it as authoritative. -->
+<!-- MOVED: the workaround ("import a new copy of the attachment or create a new study") was removed as how-to creep — it belongs in a how-to page. Ensure it is captured there. -->
+

--- a/docs-rework/odm-api/contribute/transformations/csv-to-tsv/how-to-transform-csv-to-tsv.md
+++ b/docs-rework/odm-api/contribute/transformations/csv-to-tsv/how-to-transform-csv-to-tsv.md
@@ -1,0 +1,111 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+    lines: [14, 218]
+diataxis: how-to
+tab: odm-api
+task: task-110
+tickets:
+  - ODM-13233
+---
+
+# How to transform a CSV file to a Sample group
+
+This guide explains how to convert a CSV file attached to a study into an ODM-indexable Sample metadata group using the `metadata-basic` transformation image.
+
+ODM accepts TSV files as a source of metadata but cannot directly ingest CSV files. The `metadata-basic` transformation converts CSV to TSV and automatically imports the result as a Sample group in the same study.
+
+For the general transformation concepts (configurations, images, jobs), see [About the Processors Controller](../about-processors-controller.md).
+
+## Prerequisites
+
+- An API token and Curator group membership. See [Authentication and tokens](../../../getting-started/authentication-and-tokens.md).
+- A CSV file uploaded as an attachment to your study. See [Import attached files](../../import-data/import-attached-files.md).
+- The attachment's ODM accession.
+
+## Step 1: Identify the metadata-basic image and version
+
+List available transformation images:
+
+```
+GET /api/v1/transformations/images
+```
+
+Look for entries with `name: "metadata-basic"`. Note the version you want to use (for example, `"latest"`); take the exact version string from the response above. See [Available images reference](../available-images-reference.md) for the full catalogue.
+
+## Step 2: Create a configuration
+
+Create a configuration that tells the transformation where to place the converted data:
+
+```
+POST /api/v1/transformations/configurations
+```
+
+```json
+{
+  "data": {
+    "source": { "csv": {} },
+    "destination": { "samples": {} }
+  },
+  "description": "Configuration which allows you to transform csv file into Sample group",
+  "name": "csv to samples"
+}
+```
+
+Record the `id` from the response. You can reuse this configuration for other CSV files with the same structure. See [Manage configurations](../manage-configurations.md).
+
+## Step 3: Submit the transformation job
+
+```
+POST /api/v1/transformations/jobs
+```
+
+```json
+{
+  "input_accessions": ["<ATTACHMENT_ACCESSION>"],
+  "configuration_reference": { "id": <CONFIG_ID> },
+  "image_reference": {
+    "name": "metadata-basic",
+    "version": "latest"
+  },
+  "dry_run": false
+}
+```
+
+`volume_size` is omitted because the `metadata-basic` image declares a `5Gi` default that is ample for CSV files. If you want it explicit, add `"volume_size": "5Gi"` (a string with a unit suffix) — never a bare integer.
+
+By default the job runs against the latest version of the configuration; add a `version` to the `configuration_reference` object to pin an earlier one.
+
+> **[Subject to change — ODM-13233]** The exact name and shape of the `configuration_reference` field are not yet finalized. Verify against the released API before relying on it.
+
+The response contains the integer `id` of the created job.
+
+## Step 4: Monitor the job
+
+Poll until the job reaches a terminal state:
+
+```
+GET /api/v1/transformations/jobs/{id}
+```
+
+The `status.state` field may first report `PENDING` or `WAITING`, then transitions through `RUNNING` before reaching `DONE` or `FAILED`.
+
+## Step 5: Inspect the result
+
+The transformation converts the CSV to TSV and automatically triggers the multipart sample import endpoint. A new Sample metadata group is created in ODM in the same study where the attachment was placed.
+
+To retrieve the transformation logs:
+
+```
+POST /api/v1/transformations/jobs/{id}/logs
+```
+
+> Logs remain available after the job finishes; they are archived to long-term storage and served from there once the job's Pod is removed.
+
+## Related
+
+- [About the Processors Controller](../about-processors-controller.md)
+- [Available images reference](../available-images-reference.md)
+- [Manage configurations](../manage-configurations.md)
+- [How to run a transformation](../how-to-run-a-transformation.md)
+- [Multipart uploads reference](../../import-data/multipart-uploads-reference.md)

--- a/docs-rework/odm-api/contribute/transformations/how-to-run-a-transformation.md
+++ b/docs-rework/odm-api/contribute/transformations/how-to-run-a-transformation.md
@@ -1,0 +1,156 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [20, 143]
+  - path: docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+    lines: [135, 218]
+diataxis: how-to
+tab: odm-api
+task: task-092
+tickets:
+  - ODM-13233
+  - ODM-13292
+  - ODM-13304
+---
+
+# How to run a transformation
+
+This guide covers the end-to-end steps to run a transformation job in ODM using the Processors Controller API. The process is the same regardless of which image you use: create or identify a configuration, submit a dry-run job to validate, review the logs, then submit the full run.
+
+For a conceptual overview of configurations, images, and jobs, see [About the Processors Controller](about-processors-controller.md).
+
+## Prerequisites
+
+- An API token. See [Authentication and tokens](../../getting-started/authentication-and-tokens.md).
+- Curator group membership.
+- Every study that contains an attachment listed in the job's `input_accessions` must be shared with you. Requests that reference an attachment you cannot access are rejected with a generic `Item not found or insufficient permission` message.
+- The source attachment already uploaded to a study in ODM (you need its accession). See [Import attached files](../import-data/import-attached-files.md).
+
+## Step 1: Identify the right image
+
+List available transformation images:
+
+```
+GET /api/v1/transformations/images
+```
+
+Note the `name` and `version` of the image you want to use. Use `"latest"` for the most recent version, or a specific release tag (for example, `"0.0.7"`) for reproducibility in production pipelines. See [Available images reference](available-images-reference.md) for the full catalogue and per-image guidance.
+
+## Step 2: Create or identify a configuration
+
+List existing configurations to see if one already fits your needs:
+
+```
+GET /api/v1/transformations/configurations
+```
+
+To create a new configuration, submit a `POST` request with a name, description, and the `data` field containing the image-specific processing specification:
+
+```
+POST /api/v1/transformations/configurations
+```
+
+```json
+{
+  "name": "my_study_config",
+  "description": "Configuration for study XYZ",
+  "data": {
+    "source": "csv",
+    "destination": "samples"
+  }
+}
+```
+
+The response includes the integer `id` of the created configuration. Record it — you need it in the next step. See [Manage configurations](manage-configurations.md) for full CRUD operations.
+
+## Step 3: Submit a dry-run job
+
+Submit a job with `dry_run` set to `true`:
+
+```
+POST /api/v1/transformations/jobs
+```
+
+```json
+{
+  "configuration_reference": {
+    "id": <config_id>
+  },
+  "dry_run": true,
+  "image_reference": {
+    "name": "<image_name>",
+    "version": "latest"
+  },
+  "input_accessions": ["<attachment_accession>"],
+  "volume_size": "30Gi"
+}
+```
+
+`volume_size` is a Kubernetes resource quantity string (for example `"30Gi"` for 30 GiB, or `"512Mi"`), not a plain number — the request is rejected if the value is not a valid quantity or is zero. As a guideline: for H5AD input files, allocate at least 1.4× the original file size; for 10x H5 input files, at least 4× the original file size; for CSV files, a small value such as `"30Gi"` is sufficient. If you omit `volume_size`, the image's default is used (falling back to `"30Gi"`).
+
+The body also accepts an optional `memory_size` quantity string (for example `"512Mi"`). Increase it if a job ends in `FAILED` with `status.reason: OOMKilled`.
+
+By default the job runs against the latest version of the configuration. To pin a specific version — for example, to reproduce an earlier job — add a `version` to the `configuration_reference` object:
+
+```json
+"configuration_reference": {
+  "id": <config_id>,
+  "version": <version>
+}
+```
+
+> **[Subject to change — ODM-13233]** The exact name and shape of the `configuration_reference` field are not yet finalized. Verify against the released API before relying on it.
+
+The response includes the integer `id` of the created job. Record it for monitoring.
+
+## Step 4: Monitor the job
+
+Poll the job until it reaches a terminal state:
+
+```
+GET /api/v1/transformations/jobs/{job_id}
+```
+
+The `status.state` field moves through the non-terminal states `PENDING`, `WAITING`, and `RUNNING` (the exact order is not guaranteed) before reaching a terminal state: `DONE` on success, or `FAILED` on error (check `status.reason` — for example `OOMKilled`). A job you cancel ends in `CANCELLED`.
+
+## Step 5: Review the logs
+
+```
+POST /api/v1/transformations/jobs/{job_id}/logs
+```
+
+Review the log output for:
+
+- Configuration validation messages.
+- The file structure report: which metadata keys are present in your input file.
+- Linking validation results: whether cell batch values resolve to existing ODM objects.
+- Columns flagged for automatic renaming or data type conversion.
+
+If issues are found, update the configuration using `PUT /api/v1/transformations/configurations/{id}` and repeat from Step 3. See [Manage configurations](manage-configurations.md) for the recommended iteration loop.
+
+## Step 6: Submit the full run
+
+Once the dry run completes without issues, resubmit with `dry_run` set to `false`:
+
+```json
+{
+  "configuration_reference": {
+    "id": <config_id>
+  },
+  "dry_run": false,
+  "image_reference": {
+    "name": "<image_name>",
+    "version": "latest"
+  },
+  "input_accessions": ["<attachment_accession>"],
+  "volume_size": "30Gi"
+}
+```
+
+Monitor and review logs the same way as Steps 4–5. When the job completes, the logs contain the ODM accessions of all objects that were created or updated. Logs are uploaded as an attachment to the same study.
+
+## Use-case guides
+
+- For single-cell HDF5 ingestion, see [single-cell/single-cell-getting-started.md](single-cell/single-cell-getting-started.md).
+- For CSV-to-TSV conversion, see [csv-to-tsv/how-to-transform-csv-to-tsv.md](csv-to-tsv/how-to-transform-csv-to-tsv.md).
+- For the full endpoint specifications, see [API reference](api-reference.md).

--- a/docs-rework/odm-api/contribute/transformations/job-lifecycle.md
+++ b/docs-rework/odm-api/contribute/transformations/job-lifecycle.md
@@ -1,0 +1,84 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/about-sc-hdf5-transformations.md
+    lines: [54, 77]
+  - path: docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+    lines: [178, 218]
+  - path: docs/user-guide/doc-odm-user-guide/api-reference.md
+    lines: [150, 256]
+  - path: docs/user-guide/doc-odm-user-guide/transformation-process-reference.md
+    lines: [1, 251]
+diataxis: explanation
+tab: odm-api
+tickets:
+  - ODM-13233
+  - ODM-13239
+  - ODM-13304
+  - ODM-13324
+---
+
+# Transformation job lifecycle
+
+When you submit a transformation job, the Processors Controller provisions the processing environment, tracks the job's state as it runs, and reclaims its compute resources once the job is finished. The Processors Controller does not run the transformation itself. The transformation — the containerized image running inside that environment — does the actual work: it reads its inputs, processes them, writes the resulting objects back into ODM, and uploads its log. This page explains each phase so that you can interpret status responses, reason about failures, and make informed decisions about resource settings.
+
+For the concepts behind transformations, see [About the Processors Controller](about-processors-controller.md). For the full list of job states and the job object's fields, see the [Processors Controller API reference](api-reference.md).
+
+## Submission
+
+Submitting a job is a single API call to `POST /api/v1/transformations/jobs`. The Processors Controller validates your request, registers the job, and returns a numeric job `id`. From this point on, polling `GET /api/v1/transformations/jobs/{id}` tells you the current state of the job.
+
+The configuration you submit can pin a specific version; if you don't, the job runs against the latest version. Either way, the job records the configuration version it ran against, so the audit trail stays intact and the job can be reproduced even if the configuration is updated afterwards.
+
+## Container provisioning
+
+> **[PLACEHOLDER]** The mechanism by which the Processors Controller provisions the container — including the infrastructure layer used, how the container image is pulled and started, and any queue behaviour when multiple jobs are submitted concurrently — is not yet documented here.
+
+Each transformation image is a versioned containerized processing environment. The image name and version you specify in `image_reference` determine which environment is used. The scratch volume defined by `volume_size` is allocated at this stage and is used to store the input file, intermediate files, and output before they are uploaded to ODM. Alongside it, `memory_size` sets how much memory the job is allowed to use; if the transformation exceeds it, the job fails with an out-of-memory error (see [Completion](#completion)). When you don't set these explicitly, their defaults come from the image, falling back to 30Gi of scratch storage and 512Mi of memory if the image doesn't specify them. For sizing guidance, see [Job resource parameters reference](resource-parameters-reference.md).
+
+The job's state, reported as `status.state` when you poll the job, reflects how far this setup has progressed. A newly accepted job starts as `PENDING`: it has been registered, but its processing environment has not started being set up yet — for example, it may be queued, awaiting capacity, or having its scratch storage prepared. Nothing is running at this stage, and the processing container does not exist yet. The job then moves to `WAITING` while the processing environment is being set up, typically as the transformation image is downloaded; the transformation has still not begun running. Once the environment is ready and the transformation starts processing the input, the job is `RUNNING`. From there it ends in one of three terminal states: `DONE` (finished successfully), `FAILED` (finished with an error), or `CANCELLED` (you cancelled it while it was still running — a terminal outcome distinct from failure, carrying no error reason). A further state, `UNKNOWN`, means the job's state cannot currently be determined. For a normal, successful run the order is `PENDING` → `WAITING` → `RUNNING` → `DONE`.
+
+## Execution
+
+While the job stays in the single `RUNNING` state, the transformation works through several internal phases. These are steps within one run, not separate status values — polling the job during any of them returns `RUNNING`. The phases proceed in the following order regardless of image type:
+
+**Configuration loading and validation** — the transformation configuration document is read and all fields are validated. The configuration is checked in two passes. First, its overall structure: if a required top-level setting is missing or malformed, the job can't go any further and stops immediately. If the structure is sound, every individual setting is then checked together, and all problems are reported at once — so you see the full list in one run rather than fixing one error, re-running, and hitting the next.
+
+**Input file retrieval** — the input file accessions you supplied are resolved against ODM and the files are downloaded to the scratch volume. At this stage the pipeline also retrieves the study accession and any metadata needed to determine where the output objects will be linked.
+
+**Processing** — the image-specific transformation logic runs. What it produces depends on the image. For a detailed description of each internal stage for the single-cell HDF5 image, see [Transformation process reference](single-cell/transformation-process-reference.md).
+
+**Output generation** — processed output files are prepared for upload to ODM. In dry-run mode this step is skipped.
+
+## Dry-run mode
+
+When `dry_run: true`, the transformation validates the configuration and input, runs preliminary checks including linking validation, and then exits before generating output or writing any data to ODM. Like any other job, a dry run is retained permanently: its logs stay available through the API afterwards, even though they are not uploaded to ODM as attachments. Use dry runs to iterate on your configuration before committing to a full run; for the steps, see [How to run a transformation](how-to-run-a-transformation.md).
+
+## Completion
+
+When the transformation finishes on its own, the job transitions to either `DONE` or `FAILED`; if you cancel it while it is still running, it transitions to `CANCELLED`. At this point the Processors Controller sets the job's `end_time`, recording the moment the job reached its terminal state; comparing `end_time` against `create_time` gives you the job's total duration.
+
+**On success (`DONE`):** The transformation has written its output objects into ODM and linked them to the appropriate study entities. It also uploads its log to ODM as an attachment on the study that owns the input file. This upload is skipped if `save_logs` is set to `false` in the transformation configuration.
+
+**On failure (`FAILED`):** No ODM objects are written.
+
+<!-- TODO: Confirm whether a mid-run failure can leave partial objects in ODM. If not guaranteed atomic, reword (e.g. "may not have written all, or any, objects"). -->
+
+The job log records the error that caused the failure; retrieve it via `POST /api/v1/transformations/jobs/{id}/logs` to diagnose the problem. A common failure reason is running out of memory: when this happens, the job's status carries the reason `OOMKilled`, meaning the transformation used more memory than `memory_size` allowed. The remedy is to resubmit with a larger `memory_size`.
+
+**On cancellation (`CANCELLED`):** You can cancel a job while it is still running, using `POST /api/v1/transformations/jobs/{id}/cancel`. Cancelling stops the job immediately and records it as `CANCELLED` — a terminal outcome distinct from `FAILED`, carrying no error reason. There is no choice of how the job stops.
+
+**Archival and compute cleanup:**
+
+Finishing and archiving are two separate moments. A job first reaches a terminal state (`DONE`, `FAILED`, or `CANCELLED`); shortly afterwards a background process archives its final status and full logs to permanent storage and frees the job's compute resources — the scratch volume and the processing container. Cancelling a job archives it immediately. Once a job is archived, its `archived` field flips to `true`; you see no other change, because its status and logs keep working exactly as before.
+
+The job record, its final status, and its logs are retained permanently and stay available through the API — they are never auto-deleted, and a job cannot be deleted manually. Archival frees only the compute resources; it does not remove the ODM objects the transformation produced.
+
+## Log availability
+
+A job's logs are retained permanently and are always retrievable, whether the job is still running or long finished.
+
+Via the API, using `POST /api/v1/transformations/jobs/{id}/logs`, the endpoint returns the live logs while the job runs and the archived logs once it has finished — transparently, with no change in how you call it. This applies to successful, failed, and cancelled jobs alike.
+
+Separately, the log is also uploaded to ODM as an attachment on the study that owns the input file as part of the transformation's final steps (unless `save_logs: false` in the configuration), so it sits alongside the job's other generated files.
+
+<!-- TODO: Clarify the relationship between the permanent, API-accessible log archive (new) and the existing behavior of uploading a job's log to ODM as a study attachment. The archive makes API-fetchable logs permanent on its own; whether the study-attachment upload still exists or changes is not yet specified. Do NOT state that a log must be attached to a study to persist. Resolve before publishing. -->

--- a/docs-rework/odm-api/contribute/transformations/manage-configurations.md
+++ b/docs-rework/odm-api/contribute/transformations/manage-configurations.md
@@ -1,0 +1,119 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/attachment-transformation.md
+    lines: [75, 134]
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [145, 170]
+diataxis: how-to
+tab: odm-api
+task: task-093
+tickets:
+  - ODM-13233
+  - ODM-13243
+  - ODM-13326
+---
+
+# How to manage transformation configurations
+
+This guide shows you how to develop a transformation configuration and iterate on it until it produces the results you want. A configuration is a reusable, versioned JSON document that tells an image how to process your input. The workflow below takes you from a first draft, through dry-run testing, to a configuration you can run for real and reuse across jobs.
+
+For the full field-by-field schema of every configuration endpoint, see the [API reference](api-reference.md#transformation-configurations).
+
+## Prerequisites
+
+- An API token. See [Authentication and tokens](../../getting-started/authentication-and-tokens.md).
+- Curator group membership.
+
+## The iteration loop
+
+Developing a configuration is a loop. You create a first draft, submit it as a dry-run job, review the logs, and update the configuration to fix whatever the dry run surfaced — repeating until the dry run is clean. Only then do you submit a full run.
+
+```
+Create configuration → Submit dry-run job → Review logs
+       ↑                                          |
+       └──── Update configuration ←──────────────┘
+              (if issues found)
+```
+
+Each step in the loop maps to an endpoint, covered in the sections below. The dry-run and full-run steps rely on the job-submission workflow described in [How to run a transformation](how-to-run-a-transformation.md).
+
+## Create a first draft
+
+Create a configuration with:
+
+```
+POST /api/v1/transformations/configurations
+```
+
+The request body requires `data` — the image-specific processing specification. `name` and `description` are optional but recommended, since the list and get responses surface them so you can identify the configuration later.
+
+For the `metadata-basic` image (CSV to Sample group), a minimal request looks like this:
+
+```json
+{
+  "data": {
+    "source": "csv",
+    "destination": "samples"
+  },
+  "description": "Configuration which allows you to transform csv file into Sample group",
+  "name": "csv to samples"
+}
+```
+
+The response is the configuration reference — its server-assigned `id` and the `version` (`1` for a newly created configuration):
+
+```json
+{
+  "id": 294862386,
+  "version": 1
+}
+```
+
+Keep that `id`: you use it to retrieve, update, and submit jobs against the configuration. For the single-cell HDF5 `hdf5-cells` image, the `data` field follows a different schema — see the [Configuration Reference](single-cell/configuration-reference.md).
+
+## Submit a dry run and review the logs
+
+Submit the configuration as a dry-run job, then read the job logs to see how it behaved against your real input without writing any data. The job-submission and log-retrieval endpoints are covered in [How to run a transformation](how-to-run-a-transformation.md).
+
+## Update and repeat
+
+When the logs show something to fix, update the configuration:
+
+```
+PUT /api/v1/transformations/configurations/{id}
+```
+
+The request body follows the same structure as the `POST` endpoint. Updating does not overwrite the configuration: the current state is archived as a previous version and the active version is incremented. The same `id` is reused across all iterations, and every earlier version stays retrievable, so you can audit or re-run a job with the exact parameters used in the past.
+
+Resubmit the dry-run job against the same configuration and review the logs again. Repeat until the dry run completes without errors or warnings that require action, then submit the full run.
+
+## Review your configurations
+
+At any point you can inspect what you have. To list your configurations:
+
+```
+GET /api/v1/transformations/configurations
+```
+
+The response is a paginated envelope: the configurations are in the `items` array, and `limit`/`offset` query parameters page through the results (default 100 per page). The list returns the latest version of each configuration, including its full `data`, so you can review the current state of each one without a second request. See [Pagination](api-reference.md#pagination).
+
+To retrieve a single configuration by its `id`:
+
+```
+GET /api/v1/transformations/configurations/{id}
+```
+
+This returns the latest version of that configuration as a single object, with the same fields as a list item.
+
+To work with the version history — for example, to compare against or re-run an earlier iteration — list the versions and then retrieve a specific one:
+
+```
+GET /api/v1/transformations/configurations/{id}/versions
+GET /api/v1/transformations/configurations/{id}/versions/{version}
+```
+
+The versions are returned in the `items` array of a paginated envelope. For the field-by-field schema of these and every other configuration endpoint, see the [API reference](api-reference.md#transformation-configurations).
+
+## Reuse a working configuration
+
+Configurations are reusable. Once a configuration is working correctly, you can apply it to multiple input files in subsequent jobs without recreating it.

--- a/docs-rework/odm-api/contribute/transformations/resource-parameters-reference.md
+++ b/docs-rework/odm-api/contribute/transformations/resource-parameters-reference.md
@@ -1,0 +1,50 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/api-reference.md
+    lines: [162, 184]
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [93, 95]
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [345, 345]
+diataxis: reference
+tab: odm-api
+---
+
+# Job resource parameters reference
+
+This reference covers the parameters you set at job submission time that affect how the processing environment is provisioned. These are distinct from the transformation configuration, which controls what the pipeline does with your data. Resource parameters are set in the request body of `POST /api/v1/transformations/jobs`. For the full job submission schema, see [Processors Controller API reference](api-reference.md).
+
+---
+
+## `volume_size`
+
+| Property | Value |
+|---|---|
+| Type | string (Kubernetes quantity, e.g. `30Gi`) |
+| Required | No |
+| Default | the image's `default-volume-size` label, or `30Gi` if the image declares none |
+| Example | `30Gi` |
+
+Scratch volume allocated for the duration of the job. The volume stores the input file, intermediate processing files, and output files before they are uploaded to ODM. If the volume is too small for the data being processed, the job will fail.
+
+**Sizing guidelines:**
+
+| Input format | Recommended minimum |
+|---|---|
+| H5AD | ≥ 1.4 × size of the original attachment (GB) |
+| 10x H5 | ≥ 4 × size of the original attachment (GB) |
+
+10x H5 files require significantly more scratch space because the transformation converts them to H5AD internally before processing begins. For example, a 5 GB H5 file requires `volume_size` of at least `20Gi`.
+
+---
+
+## `memory_size`
+
+| Property | Value |
+|---|---|
+| Type | string (Kubernetes quantity, e.g. `512Mi`) |
+| Required | No |
+| Default | the image's `default-memory-size` label, or `512Mi` if the image declares none |
+| Example | `512Mi` |
+
+Memory allocated to the transformation Pod. It is applied as both the Pod's memory request and limit, so it acts as a hard cap: a job that exceeds it is terminated and reported as `FAILED` with status reason `OOMKilled`. If that happens, increase `memory_size` or adjust the transformation configuration. The value must be a valid Kubernetes quantity greater than zero, otherwise the request is rejected with HTTP 422.

--- a/docs-rework/odm-api/contribute/transformations/single-cell/about-single-cell-transformations.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/about-single-cell-transformations.md
@@ -1,0 +1,103 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/about-sc-hdf5-transformations.md
+    lines: [1, 62]
+  - path: docs/user-guide/doc-odm-user-guide/about-sc-hdf5-transformations.md
+    lines: [74, 97]
+diataxis: explanation
+tab: odm-api
+task: task-096
+tickets:
+  - ODM-13324
+---
+
+# About single-cell HDF5 transformations
+
+The single-cell HDF5 transformation converts a single-cell HDF5 file into the ODM-compatible output. It extracts expression data and cell metadata, optionally harmonises metadata, and can create or update biosample objects in ODM. The output objects are imported and linked automatically. The result is feature-level indexed data ready for downstream analysis and cross-study discovery without manual file preparation.
+
+The transformation runs via the ODM Processors Controller API. For an overview of configurations, images, and jobs — the three building blocks shared by all transformations — see [About the Processors Controller](../about-processors-controller.md).
+
+## The ODM entity model for single-cell data
+
+Understanding the transformation requires familiarity with how ODM represents single-cell experiments.
+
+**Sample, Library, and Preparation groups** (collectively referred to as SLP) represent the biological and experimental context. A Sample describes a biological specimen; a Library describes the sequencing library prepared from it; a Preparation describes a preparation step. These entities either already exist in ODM or can be created by the transformation.
+
+**A Cell Group** is the collection of individual cells from an experiment, together with their metadata. Each Cell Group is linked to one or more parent groups of a single SLP type (Sample, Library, or Preparation). This linkage allows ODM to associate cell-level observations with the correct experimental context.
+
+**An Expression Group** represents the gene-by-cell expression matrix — compressed for efficient retrieval — along with computed dataset statistics. An Expression Group is always linked to a Cell Group.
+
+```mermaid
+graph TD
+    subgraph CTX["Biological & experimental context — SLP"]
+        direction LR
+        S["Sample<br/><i>biological specimen</i>"]
+        L["Library<br/><i>sequencing library</i>"]
+        P["Preparation<br/><i>preparation step</i>"]
+    end
+
+    CG["Cell Group<br/><i>cells + per-cell metadata</i>"]
+    EG["Expression Group<br/><i>gene × cell matrix + dataset stats</i>"]
+
+    EG -->|always linked to| CG
+    CG -->|"linked to one or more groups<br/>of a <b>single</b> SLP type"| CTX
+
+    classDef ctx fill:#D8F3FF,color:#023F79,stroke:#0470BE,stroke-width:2px,font-weight:bold
+    classDef grp fill:#D8F9EA,color:#023F79,stroke:#34AF7C,stroke-width:2px,font-weight:bold
+    class S,L,P ctx
+    class CG,EG grp
+    style CTX fill:#ffffff,stroke:#0470BE,stroke-width:1px
+```
+
+The transformation creates the Cell Group and Expression Group and links them into the existing (or newly created) SLP structure. This is why the configuration requires specifying how the resulting Cell Group connects to its parent. For the broader ODM data model, see [Data model](../../../../overview/data-model/index.md).
+
+## What the transformation reads from the source file
+
+The transformation extracts three types of data from an HDF5 source file.
+
+**Cell metadata** is extracted primarily from `obs` in H5AD input (or the equivalent in 10x H5). This includes per-cell annotations such as barcodes, cluster assignments, and quality control metrics. Multidimensional representations from `obsm` (PCA, UMAP coordinates) and pairwise cell annotations from `obsp` can also be extracted.
+
+**Feature metadata** is extracted from `var`, and optionally from `varm` and `varp`. This includes per-gene annotations such as gene identifiers and gene names.
+
+**The expression matrix** is extracted from `X`, which contains count or normalised expression values. The transformation validates that the number of features in the matrix matches the extracted feature metadata, then writes the matrix in a Brotli-compressed format optimised for ODM ingestion.
+
+## The role of metadata curation
+
+Metadata curation standardises cell metadata so that it can be imported, linked, and indexed correctly in ODM. Certain fields must use expected names and data types to ensure consistent linking and indexing — the transformation handles this during processing.
+
+As part of curation, the transformation performs automatic attribute mapping: commonly used attribute names from tools such as Seurat, Scanpy, or Cell Ranger are recognised and renamed to canonical ODM API names without any configuration. Attributes that do not match any known name are retained and their names are automatically converted to camelCase. Curation applies only to the data produced for import into ODM — the source file is not modified. For the full list of recognised names, see [Attribute mapping reference](attribute-mapping-reference.md).
+
+## Biosample metadata and the aggregation model
+
+Some single-cell datasets store tissue, disease, or other biosample-level attributes in cell metadata, repeating the same values for every cell. The transformation can aggregate these attributes into related biosample objects — Sample, Library, or Preparation groups in ODM.
+
+Aggregation is performed by grouping cells using a designated biosample identifier. Only attributes that are consistent across all cells in the same biosample are assigned to the related biosample objects. Attributes assigned to biosample objects are automatically removed from cell metadata, reducing duplication.
+
+## Linking created objects
+
+When the transformation uploads a Cell Group, it links it to a parent Sample, Library, or Preparation entity. This is usually handled automatically: if the transformation creates new SLP objects, the Cell Group is linked to them; otherwise, the transformation identifies the most appropriate existing SLP target in ODM. You can override this by specifying the target explicitly in the configuration. For the full resolution rules, see [Transformation process reference](transformation-process-reference.md).
+
+The Expression Group created by the transformation is linked to the corresponding Cell Group.
+
+## Supported input formats
+
+The transformation accepts HDF5-based input: H5AD (AnnData), 10x Genomics H5 (converted internally to H5AD before processing), and legacy 10x H5 (v<3, single-genome only). For the full per-format catalogue, see [Available images reference](../available-images-reference.md).
+
+## Transformation logs
+
+A single-cell job produces a processing log like any other transformation. For what the log records, how it is retained, and how to retrieve it, see [About the Processors Controller](../about-processors-controller.md#transformation-logs).
+
+## Known limitations
+
+Currently, only one transformation process can be run per attachment. If you need to run another transformation job on the same data, import a new copy of the attachment or create a new study.
+
+<!-- TODO: verify — the one-transformation-per-attachment constraint is a platform-level rule not present in the transformation-images-develop/ image code. Confirm against an authoritative source before publishing. (Same constraint also flagged in available-images-reference.md.) -->
+
+## Where to start
+
+- **Start here:** [Single-cell getting started](single-cell-getting-started.md) — a single-cell quickstart from upload to queried data.
+- **General workflow:** [How to run a transformation](../how-to-run-a-transformation.md) — the step-by-step API workflow applicable to any transformation type.
+- **Per-task how-tos:** [Ingest cell and expression data](ingest-cell-and-expression.md), [Create sample/library/preparation groups](create-sample-library-preparation-groups.md), [Update existing biosample metadata](update-existing-biosample-metadata.md).
+- **Dry-run iteration:** [Iterate on a configuration using dry runs](iterate-with-dry-runs.md) and [Discover which biosample attributes are available](discover-biosample-attributes.md).
+- **Configuration spec:** [Configuration reference](configuration-reference.md) — the full `data` field schema for `hdf5-cells`.
+- **Pipeline internals:** [Transformation process reference](transformation-process-reference.md) — the internal processing pipeline.

--- a/docs-rework/odm-api/contribute/transformations/single-cell/attribute-mapping-reference.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/attribute-mapping-reference.md
@@ -1,0 +1,67 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/attribute-mapping.md
+    lines: [1, 61]
+diataxis: reference
+tab: odm-api
+task: task-107
+---
+
+# Attribute mapping reference
+
+During metadata curation, the transformation automatically maps commonly used attribute names found in source HDF5 files to the canonical ODM API names.
+
+Mapping is applied separately to cell metadata and feature metadata. When an attribute in the source file matches one of the known alternative names listed below, it is renamed to the corresponding ODM API display name. Attributes that do not match any known name are converted to camelCase.
+
+## Cell metadata attributes
+
+| ODM API display name | Alternative names |
+|---|---|
+| cellID | — |
+| barcode | — |
+| batch | `sample_id`, `sample`, `run_id` |
+| cellType | `cell_type`, `celltype`, `ident`, `labels` |
+| cluster | `cluster_louvain`, `cluster_leiden`, `seurat_clusters` |
+| nCounts | `n_counts`, `umi_count`, `nCount_RNA`, `total_umi`, `n_umi`, `n_reads`, `nUMI`, `UMI_count` |
+| percentMito | `percent_mito`, `percent_mt`, `percent.mt`, `pct_mt`, `pct_mito`, `pct_counts_mito`, `percent.mito`, `percent.mito.raw`, `mito_ratio`, `pct_counts_mt` |
+| umap | `X_umap`, `UMAP` |
+| pca | `X_pca`, `PCA` |
+| tsne | `X_tsne`, `tSNE` |
+| pcaHarmony | `pca_harmony`, `X_harmony`, `harmony_embedding`, `X_pca_harmony` |
+| nGenes | `n_genes`, `n_genes_by_counts`, `nGene`, `n_features`, `nFeature_RNA`, `genes_detected`, `detected_genes`, `gene_count`, `Total_Genes_Detected` |
+| mitoCounts | `mito_counts`, `total_counts_mt`, `total_counts_mito`, `subsets_mt_sum`, `mt_sum`, `MT_sum` |
+| riboCounts | `ribo_counts`, `total_counts_ribo`, `total_counts_rb`, `subsets_ribo_sum`, `rb_counts`, `rb_sum` |
+| percentRibo | `percent_ribo`, `percent_rb`, `percent.rb`, `pct_counts_ribo`, `ribo_ratio`, `pct_ribo`, `pct_counts_rb`, `pct_counts_rrna` |
+| percentHemoglobin | `percent_hb`, `pct_hb`, `hemoglobin_fraction`, `prop_hb`, `percent_hemoglobin` |
+| doubletStatus | `doublet_status`, `is_doublet`, `predicted_doublet`, `multiplet_status` |
+| doubletScore | `doublet_score`, `scrublet_score`, `doublet_probability`, `multiplet_score`, `doublet_stat` |
+| sScore | `S_score`, `s.score`, `S.Score`, `s_phase_score`, `S_phase_probability` |
+| g2mScore | `G2M_score`, `g2m.score`, `G2M.Score`, `g2m_phase_score`, `G2M_phase_probability` |
+| cellCycle | `phase`, `cell_cycle_phase`, `cc_phase`, `cycle_stage` |
+| ambientFraction | `ambient_fraction`, `decontX_score`, `rho`, `contamination_fraction`, `ambient_rna_percent`, `soup_fraction`, `soup_frac` |
+
+## Feature metadata attributes
+
+| ODM API display name | Alternative names |
+|---|---|
+| geneId | `gene_id` (index), `gene_ids`, `ensembl_id`, `feature_id`, `stable_id`, `ENSEMBL` |
+| gene | `symbol`, `symbols`, `gene_symbol`, `gene_symbols`, `feature_name`, `display_name`, `name`, `gene_name` |
+| totalCounts | `total_counts`, `gene_total`, `sum_counts`, `count_sum`, `total_umis` |
+| nCellsByCounts | `n_cells_by_counts`, `n_cells`, `num_cells`, `n_obs`, `num_cells_expressed` |
+| meanCounts | `mean_counts`, `avg_exp`, `obs_mean`, `means` |
+| pctDropoutByCounts | `pct_dropout_by_counts`, `pct_dropout`, `percent_dropout`, `dropout_rate` |
+
+## Gene ID to name mapping {#gene-id-to-name-mapping}
+
+When feature metadata contains a `geneId` column but no gene name column, the transformation can automatically resolve gene names from a built-in reference. This is controlled by the `map_gene_ids_to_names` parameter in the `feature_metadata` configuration block, which is enabled by default. Set it to `false` for proteomics or other non-gene-ID data where this behaviour is not appropriate.
+
+The mapping uses Ensembl and NCBI reference data. Both Ensembl gene IDs (for example, `ENSG...`) and NCBI gene IDs are supported. The following organisms are supported in `hdf5-cells`:
+
+| Organism | Genome version | Ensembl release | NCBI release |
+|----------|----------------|-----------------|--------------|
+| *Homo sapiens* | GRCh38.p14 | 115 | GCF_000001405.40-RS_2025_08 |
+| *Mus musculus* | GRCm39 | 115 | GCF_000001635.27-RS_2024_02 |
+| *Rattus norvegicus* | GRCr8 | 115 | GCF_036323735.1-RS_2024_02 |
+| *Sus scrofa* | Sscrofa11.1 | 115 | 106 |
+
+> The gene ID column must be named `geneId` for mapping to be performed. If the column has a different name in the source file, ensure it is covered by the feature metadata attribute mapping above so that it is renamed to `geneId` before this step runs.

--- a/docs-rework/odm-api/contribute/transformations/single-cell/configuration-reference.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/configuration-reference.md
@@ -1,0 +1,154 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/configuration-reference.md
+    lines: [1, 146]
+diataxis: reference
+tab: odm-api
+task: task-105
+---
+
+# Configuration reference: Single-cell HDF5 transformation
+
+The configuration is validated at the start of every run. If `file_type` is missing or invalid, the pipeline raises an error immediately. All other validation errors are collected and reported together. Unrecognised keys are ignored with a warning.
+
+For related documentation: [About single-cell transformations](about-single-cell-transformations.md) · [How-to guides](ingest-cell-and-expression.md) · [API reference](../api-reference.md) · [Transformation process reference](transformation-process-reference.md)
+
+---
+
+## Top-level parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_type` | `string` | **Yes** | — | Format of the input file. Accepted values: `"h5ad"`, `"h5"`. |
+| `save_logs` | `boolean` | No | `true` | When `false`, logs are not saved as an attachment after the run. Has no effect when the job is submitted with `dry_run: true`. |
+
+---
+
+## `biosample_metadata`
+
+Settings for extracting, transforming, and exporting cell-level metadata to Sample, Library, or Preparation entities. The entire section is optional.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `metadata_keys` | `dict[string, string]` | Yes | — | Maps HDF5 group keys to metadata types. Use `"obs": "metadata"` to read standard cell metadata. |
+| `biosample_column_name` | `string` | Yes | — | Column identifying which biosample each cell belongs to. Rows are grouped by this column for aggregation. |
+
+**`metadata_keys` example:**
+```json
+{ "obs": "metadata" }
+```
+
+### `biosample_metadata.sample`
+
+Settings for exporting metadata to the Sample entity. Optional.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `create_new_group` | `boolean` | `false` | When `true`, creates a new Sample group in ODM and links it to the study. |
+| `template_id` | `string` | — | Template ID for the new Sample group. Falls back to the study default if omitted. |
+| `columns_to_export` | `list[string]` | — | Cell metadata columns to include in the exported Sample metadata. Only columns constant per biosample are eligible; exported columns are dropped from cell metadata. |
+| `columns_renaming_map` | `dict[string, string]` | — | Maps source column names to new names in the exported metadata. |
+| `columns_to_fill_missing_values` | `dict[string, string]` | — | Default values for missing entries in specified columns. |
+| `columns_to_curate_values` | `dict[string, dict[string, string]]` | — | Maps specific values in a column to replacement values. |
+
+**Examples:**
+```json
+{ "columns_renaming_map": { "tissue_type": "tissueType" } }
+{ "columns_to_fill_missing_values": { "disease": "unknown" } }
+{ "columns_to_curate_values": { "tissue": { "PBMCs": "peripheral blood mononuclear cells" } } }
+```
+
+### `biosample_metadata.library`
+
+Accepts the same parameters as `biosample_metadata.sample`, plus:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `linking_group` | `string` | — | Accession of an existing Sample group to link the new Library group to. If omitted, the pipeline uses a Sample group from the same run or pre-fetched accessions. |
+
+### `biosample_metadata.preparation`
+
+Accepts the same parameters as `biosample_metadata.library`, including `linking_group`.
+
+> **Constraint:** Only one of `library` or `preparation` may have `columns_to_export` set in the same configuration.
+
+---
+
+## `cell_metadata`
+
+Settings for extracting and transforming cell-level metadata. Optional. If absent, no Cell Group is created.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `metadata_keys` | `dict[string, string]` | Yes | — | Maps HDF5 group keys to metadata types. At least one key with value `"metadata"` is required. |
+| `linking_group` | `dict[string, string \| list[string] \| null]` | No | — | Specifies the parent SLP entity (`sample`, `library` or `preparation`) to link the Cell Group to. Empty value triggers auto-discovery of all available accessions. For full linking resolution rules, see [Linking group determination](transformation-process-reference.md#13-linking-group-determination). |
+| `columns_to_drop` | `list[string]` | No | — | Column names to remove before processing. |
+| `columns_renaming_map` | `dict[string, string]` | No | — | Maps source column names to new names. |
+| `columns_to_fill_missing_values` | `dict[string, string]` | No | — | Default values for missing entries. |
+| `columns_to_curate_values` | `dict[string, dict[string, string]]` | No | — | Replacement values for specific entries in specified columns. |
+| `set_column_value` | `dict[string, string]` | No | — | Sets a constant value for all rows. Can add new columns or overwrite existing ones. |
+| `columns_to_preserve_name` | `list[string]` | No | — | Columns to exempt from internal name standardisation (e.g. Leiden cluster columns with decimal suffixes). |
+| `add_qc_metrics` | `boolean` | No | `true` | When `true`, adds QC metrics (counts, genes, mitochondrial/ribosomal presence) if not already present. Skipped when the job is submitted with `dry_run: true`. |
+
+**`metadata_keys` accepted values (H5AD):**
+
+| Key | Value | Description |
+|-----|-------|-------------|
+| `obs` | `metadata` | Standard cell annotations |
+| `obsm` | `embedding` | Multidimensional cell data (PCA, UMAP, etc.) |
+| `obsp` | `pairwise` | Pairwise cell annotations |
+
+For H5 files, use the same H5AD key names — the transformation maps them to the correct internal structure.
+
+**Examples:**
+```json
+{ "metadata_keys": { "obs": "metadata", "obsm": "embedding" } }
+{ "linking_group": { "library": "GSF017080" } }
+{ "columns_to_drop": ["taxon", "organism_id"] }
+{ "columns_renaming_map": { "sample": "batch", "pctmt": "percentMito" } }
+{ "set_column_value": { "sample_id": "lung_1" } }
+{ "columns_to_preserve_name": ["cluster_leiden_0.5"] }
+```
+
+---
+
+## `feature_metadata`
+
+Settings for extracting and transforming feature (gene)-level metadata. Optional.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `metadata_keys` | `dict[string, string]` | Yes | — | Maps HDF5 group keys to metadata types. At least one key with value `"metadata"` is required. |
+| `columns_to_drop` | `list[string]` | No | — | Column names to remove from feature metadata. |
+| `columns_renaming_map` | `dict[string, string]` | No | — | Maps source column names to new names. |
+| `columns_to_fill_missing_values` | `dict[string, string]` | No | — | Default values for missing entries. |
+| `columns_to_curate_values` | `dict[string, dict[string, string]]` | No | — | Replacement values for specific entries. |
+| `set_column_value` | `dict[string, string]` | No | — | Sets a constant value for all rows. |
+| `columns_to_preserve_name` | `list[string]` | No | — | Columns to exempt from internal name standardisation. |
+| `map_gene_ids_to_names` | `boolean` | No | `true` | When `true`, maps gene IDs to gene names if names are absent and `geneId` column is present. Set to `false` for proteomics or non-gene-ID data. |
+
+**`metadata_keys` accepted values (H5AD):**
+
+| Key | Value | Description |
+|-----|-------|-------------|
+| `var` | `metadata` | Standard feature annotations |
+| `varm` | `embedding` | Multidimensional feature data |
+| `varp` | `pairwise` | Pairwise feature annotations |
+
+---
+
+## `cell_expression`
+
+Settings for extracting and uploading the cell expression matrix. Optional. If absent, no Expression Group is created.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `data_class` | `string` | **Yes** | — | Data class label for the expression data (e.g. `"Single-cell transcriptomics"`). |
+| `compression_level` | `integer` (0–9) | No | `4` | Brotli compression level. Higher values produce smaller files at the cost of longer compression time. |
+| `chunk_size` | `integer` | No | inferred | Number of features processed per chunk. Calculated automatically from available memory if omitted. |
+| `max_buffer_size` | `integer` | No | `50` | Amount of data (in MB) held in memory before being flushed to disk during writing. |
+| `number_format` | `string` | No | inferred | Numeric precision of output values. Accepts printf-style (`"%.7g"`, `"%d"`) or NumPy dtype (`"float32"`, `"int64"`). |
+| `columns_to_drop` | `list[string]` | No | — | Column names to remove from expression metadata. |
+| `columns_renaming_map` | `dict[string, string]` | No | — | Maps source column names to new names. |
+| `set_column_value` | `dict[string, string]` | No | — | Sets a constant value for all rows in specified columns. |
+| `source_file_metadata` | `boolean` | No | `true` | When `true`, metadata from the source HDF5 attachment is read and included in expression metadata. Summary statistics (cell count, feature count, sparsity, etc.) are always appended regardless of this flag. |

--- a/docs-rework/odm-api/contribute/transformations/single-cell/configure-metadata-curation.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/configure-metadata-curation.md
@@ -1,0 +1,89 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [349, 406]
+diataxis: how-to
+tab: odm-api
+task: task-103
+---
+
+# How to configure metadata curation
+
+This guide explains how to apply curation operations to cell metadata, feature metadata, or biosample metadata during a single-cell HDF5 transformation.
+
+## Where these operations apply
+
+Curation operations are available in the `cell_metadata`, `feature_metadata`, and per-entity settings within `biosample_metadata`. They are applied in the order listed below.
+
+## Order of operations
+
+### 1. Drop columns
+
+Remove columns before any other processing:
+
+```json
+"columns_to_drop": ["taxon", "organism_id"]
+```
+
+### 2. Rename columns
+
+Map source column names to new names:
+
+```json
+"columns_renaming_map": {
+  "sample": "batch",
+  "pctmt": "percentMito"
+}
+```
+
+### 3. Replace specific values
+
+Replace known values within a column:
+
+```json
+"columns_to_curate_values": {
+  "sample": {
+    "LGVXCTRL1": "lung_healthy_1"
+  }
+}
+```
+
+### 4. Fill missing values
+
+Provide a default value for missing entries:
+
+```json
+"columns_to_fill_missing_values": {
+  "batch": "unknown"
+}
+```
+
+### 5. Set a constant value for all rows
+
+Set all rows in a column to the same value. This can add new columns or overwrite existing ones:
+
+```json
+"set_column_value": {
+  "sample_id": "lung_1"
+}
+```
+
+## Attribute name standardisation
+
+After all explicit column operations, the transformation applies automatic attribute name standardisation: column names that match known ODM canonical names are mapped to those names; non-standard names are converted to camelCase. This step is automatic and does not need to be configured.
+
+For the full list of recognised column names and their ODM equivalents, see `attribute-mapping-reference.md`.
+
+## Exempt a column from standardisation
+
+To prevent a specific column from being automatically renamed (for example, a Leiden cluster column with a decimal suffix), list it in `columns_to_preserve_name`:
+
+```json
+"columns_to_preserve_name": ["cluster_leiden_0.5"]
+```
+
+## Related
+
+- [Configuration reference](configuration-reference.md) — full parameter specifications for all curation fields.
+- `attribute-mapping-reference.md` — the complete mapping of known column names to ODM canonical names.
+- [Ingest cell and expression data from an H5AD file](ingest-cell-and-expression.md)

--- a/docs-rework/odm-api/contribute/transformations/single-cell/create-sample-library-preparation-groups.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/create-sample-library-preparation-groups.md
@@ -1,0 +1,81 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [223, 272]
+diataxis: how-to
+tab: odm-api
+task: task-099
+---
+
+# How to create Sample, Library, or Preparation groups from an H5AD file
+
+This guide explains how to derive Sample, Library, or Preparation (SLP) groups in ODM from biosample-level attributes stored in the cell metadata of your HDF5 file.
+
+## When to use this
+
+Use this guide when your study does not yet have SLP groups in ODM and your HDF5 file contains biosample-level attributes (such as tissue, disease, or donor_id) repeated per cell that you want to promote into ODM entities.
+
+If SLP groups already exist and you only need to add single-cell data, see [Ingest cell and expression data from an H5AD file](ingest-cell-and-expression.md) instead.
+
+## Prerequisites
+
+- An API token and Curator group membership. See [Authentication and tokens](../../../getting-started/authentication-and-tokens.md).
+- The HDF5 file uploaded as an attachment to your study in ODM.
+
+For the full job submission workflow, see [How to run a transformation](../how-to-run-a-transformation.md).
+
+## Configuration
+
+Identify the column in your cell metadata that acts as the biosample identifier. Set it as `biosample_column_name`. Under the relevant entity (`sample`, `library`, or `preparation`), set `create_new_group: true` and list the columns you want to export:
+
+```json
+{
+  "file_type": "h5ad",
+  "biosample_metadata": {
+    "metadata_keys": {
+      "obs": "metadata"
+    },
+    "biosample_column_name": "sample_id",
+    "sample": {
+      "create_new_group": true,
+      "columns_to_export": ["tissue", "disease", "donor_id"]
+    }
+  },
+  "cell_metadata": {
+    "metadata_keys": {
+      "obs": "metadata",
+      "obsm": "embedding"
+    }
+  },
+  "feature_metadata": {
+    "metadata_keys": {
+      "var": "metadata"
+    }
+  },
+  "cell_expression": {
+    "data_class": "Single-cell transcriptomics"
+  }
+}
+```
+
+The `cell_metadata`, `feature_metadata`, and `cell_expression` sections are included because a single-cell run normally creates the SLP groups, Cell Group, and Expression Group together — the Cell Group needs an SLP parent to link to. Omit those sections if you only want to create SLP groups.
+
+The transformation aggregates cells by `biosample_column_name`. It exports the columns you list in `columns_to_export`; each must be constant across all cells within a biosample, or the job fails. Use the [discovery dry-run](discover-biosample-attributes.md) first to find eligible columns. Exported columns are automatically removed from the cell metadata.
+
+**Constraint:** only one of `library` or `preparation` may be created or updated in the same configuration — that is, only one may carry `create_new_group` or `columns_to_export`.
+
+## Create a placeholder group for linking only
+
+If you need a Library group to exist for linking purposes but do not need to export any attributes from it, set `create_new_group: true` and omit `columns_to_export`:
+
+```json
+"library": {
+  "create_new_group": true
+}
+```
+
+## Related
+
+- [Discover which biosample attributes are available](discover-biosample-attributes.md) — use a dry run to identify which columns are uniform per biosample before committing to `columns_to_export`.
+- [Configuration reference](configuration-reference.md) — full `biosample_metadata` block schema.
+- [Transformation process reference](transformation-process-reference.md)

--- a/docs-rework/odm-api/contribute/transformations/single-cell/curated-public-datasets.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/curated-public-datasets.md
@@ -1,0 +1,244 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/dataset-import-commands.md
+    lines: [1, 196]
+  - path: docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/public-dataset-configurations-mapping.md
+    lines: [1, 25]
+diataxis: reference
+tab: odm-api
+task: task-108
+---
+
+# Curated public datasets: import commands and configurations
+
+Each curated single-cell dataset below ships with a tested import command and a pre-validated transformation configuration. For a given dataset, use its import command to load it into ODM, then run a transformation job with the configuration listed in that dataset's section.
+
+The import commands use the `odm-import-data` CLI and upload the study and sample/library metadata alongside the H5AD attachment, ready for transformation. Replace `<HOST>`, `<TOKEN>`, and `<TEMPLATE>` with your ODM instance URL, API token, and template ID before running. Commands can be run independently and in any order.
+
+Recommended template: [Public dataset template](https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/templates/public_studies_template_demo.json)
+
+> Because these configurations have been pre-validated against their datasets, you can skip the dry-run step when transforming the curated catalogue.
+
+> Two datasets — **GSE192740** and **GSE198623** — contain multiple species and upload two H5AD files (human and mouse, or human and pig) within a single command.
+
+For what the configuration fields mean, see the [Configuration reference](configuration-reference.md).
+
+---
+
+## Configuration index
+
+Several datasets share an aggregated configuration. Each dataset's own section repeats the configuration that applies to it.
+
+| Configuration | Datasets |
+|---|---|
+| [`aggregated_config_1`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_1.json) | HeartDiversityTucker10x · SCP1303 · GSE192740_human · GSE192740_mouse · GSE292928 · GSE148434 |
+| [`aggregated_config_2`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_2.json) | GSE198623_human · GSE198623_pig |
+| [`aggregated_config_3`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_3.json) | GSE148073 · FibroticLiverWatsonMERFISH |
+| [`GSE156793`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/GSE156793.json) | GSE156793 |
+| [`GSE165045`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/GSE165045.json) | GSE165045 |
+
+---
+
+## HeartDiversityTucker10x
+
+**Configuration:** [`aggregated_config_1`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_1.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/HeartDiversityTucker10x/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/HeartDiversityTucker10x/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/HeartDiversityTucker10x/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/HeartDiversityTucker10x/healthy_human_4chamber_map_unnormalized_V4.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/HeartDiversityTucker10x/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## SCP1303
+
+**Configuration:** [`aggregated_config_1`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_1.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/SCP1303/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/SCP1303/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/SCP1303/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/SCP1303/human_dcm_hcm_scportal_03.17.2022.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/cardiovascular_diseases/SCP1303/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## GSE156793
+
+**Configuration:** [`GSE156793`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/GSE156793.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/healthy_cell_atlases/GSE156793/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/healthy_cell_atlases/GSE156793/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/healthy_cell_atlases/GSE156793/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/healthy_cell_atlases/GSE156793/GSE156793_all_organs_annotated_with_genes.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/healthy_cell_atlases/GSE156793/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## FibroticLiverWatsonMERFISH
+
+**Configuration:** [`aggregated_config_3`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_3.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/FibroticLiverWatsonMERFISH/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/FibroticLiverWatsonMERFISH/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/FibroticLiverWatsonMERFISH/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/FibroticLiverWatsonMERFISH/GSE210077_adata_healthy_diseased_nucseq_sparse.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/FibroticLiverWatsonMERFISH/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## GSE165045
+
+**Configuration:** [`GSE165045`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/GSE165045.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/GSE165045/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/GSE165045/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/GSE165045/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/GSE165045/GSE165045_merged_with_TCR.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/inflammatory_diseases/GSE165045/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## GSE148073
+
+**Configuration:** [`aggregated_config_3`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_3.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE148073/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE148073/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE148073/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE148073/GSE148073_merged_data_new.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE148073/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## GSE192740 (human + mouse)
+
+**Configuration:** [`aggregated_config_1`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_1.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE192740/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE192740/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE192740/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE192740/GSE192740_human_combined_sparse.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE192740/data_human.tsv \
+  -dc 'Single-cell transcriptomics' \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE192740/GSE192740_mouse_combined_sparse.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE192740/data_mouse.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## GSE198623 (human + pig)
+
+**Configuration:** [`aggregated_config_2`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_2.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE198623/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE198623/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE198623/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE198623/GSE198623_human_processed.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE198623/data_human.tsv \
+  -dc 'Single-cell transcriptomics' \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE198623/GSE198623_pig_processed.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE198623/data_pig.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## GSE292928
+
+**Configuration:** [`aggregated_config_1`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_1.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE292928/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE292928/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE292928/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE292928/GSE292928_GEX_only_cellbender_sparse.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/metabolic_diseases/GSE292928/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```
+
+---
+
+## GSE148434
+
+**Configuration:** [`aggregated_config_1`](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/extras/aggregated_config_1.json)
+
+```bash
+odm-import-data \
+  --server <HOST> \
+  --token <TOKEN> \
+  --study https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/neurodegenerative_diseases/GSE148434/study.tsv \
+  --samples https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/neurodegenerative_diseases/GSE148434/samples.tsv \
+  --libraries https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/neurodegenerative_diseases/GSE148434/libraries.tsv \
+  -fl https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/neurodegenerative_diseases/GSE148434/GSE148434_merged_data.h5ad \
+  -flm https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/non_onco/single_cell/neurodegenerative_diseases/GSE148434/data.tsv \
+  -dc 'Single-cell transcriptomics' \
+  --template <TEMPLATE> \
+  --allow-duplicates
+```

--- a/docs-rework/odm-api/contribute/transformations/single-cell/discover-biosample-attributes.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/discover-biosample-attributes.md
@@ -1,0 +1,59 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [298, 320]
+diataxis: how-to
+tab: odm-api
+task: task-101
+---
+
+# How to discover which biosample attributes are available
+
+This guide explains how to use a dry-run job to identify which cell-level metadata columns are uniform per biosample in your HDF5 file, so you can plan your `columns_to_export` before a full run.
+
+## When to use this
+
+Use this when you are planning a biosample export and want to know which attributes are available before committing to a `columns_to_export` list. No data is created or updated in ODM.
+
+## Prerequisites
+
+- An API token and Curator group membership. See [Authentication and tokens](../../../getting-started/authentication-and-tokens.md).
+- The HDF5 file uploaded as an attachment to your study.
+
+## Configuration (discovery mode)
+
+Configure `biosample_metadata` with `metadata_keys` and `biosample_column_name`, and leave out `columns_to_export`. Discovery analyses column uniformity across all `obs` columns relative to `biosample_column_name` and is entity-agnostic, so no Sample, Library, or Preparation entity object is needed:
+
+```json
+{
+  "file_type": "h5ad",
+  "biosample_metadata": {
+    "metadata_keys": {
+      "obs": "metadata"
+    },
+    "biosample_column_name": "sample_id"
+  }
+}
+```
+
+Set `biosample_column_name` to a column that actually exists in your file's `obs`. If the named column is not present in the cell metadata, the job aborts with an error.
+
+## Submit as a dry run
+
+When submitting the job, set `dry_run: true` in the request body. Dry-run mode is required for this step — the uniform-attribute report is produced only when `dry_run` is `true`. A normal run with no `columns_to_export` produces no report. For the full submission steps, see [How to run a transformation](../how-to-run-a-transformation.md).
+
+## What the logs report
+
+The transformation logs include:
+
+- The number of unique biosamples found.
+- The list of columns that are constant across all cells per biosample (eligible for export).
+
+No ODM objects are created or modified.
+
+## Next steps
+
+Use the logged list to plan your `columns_to_export` configuration, then move to:
+
+- [Create Sample, Library, or Preparation groups](create-sample-library-preparation-groups.md) — if SLP groups do not yet exist.
+- [Update existing biosample metadata](update-existing-biosample-metadata.md) — if SLP groups already exist.

--- a/docs-rework/odm-api/contribute/transformations/single-cell/ingest-cell-and-expression.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/ingest-cell-and-expression.md
@@ -1,0 +1,90 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [173, 222]
+diataxis: how-to
+tab: odm-api
+task: task-098
+---
+
+# How to ingest cell and expression data from an H5AD file
+
+This guide explains how to add a single-cell layer (Cell Group and Expression Group) to a study that already has Sample, Library, or Preparation groups in ODM.
+
+## When to use this
+
+Use this guide when your study already has SLP groups in ODM and you need to add single-cell data on top of them.
+
+If your study does not yet have SLP groups, see [Create Sample, Library, or Preparation groups from your H5AD file](create-sample-library-preparation-groups.md) instead.
+
+## Prerequisites
+
+- An API token and Curator group membership. See [Authentication and tokens](../../../getting-started/authentication-and-tokens.md).
+- The HDF5 file uploaded as an attachment to your study in ODM.
+- Sample, Library, or Preparation groups already present in the study.
+
+For the full job submission workflow, see [How to run a transformation](../how-to-run-a-transformation.md).
+
+## Configuration
+
+Configure `cell_metadata`, `feature_metadata`, and `cell_expression` in your configuration's `data` field:
+
+```json
+{
+  "file_type": "h5ad",
+  "cell_metadata": {
+    "metadata_keys": {
+      "obs": "metadata",
+      "obsm": "embedding"
+    },
+    "columns_to_drop": ["taxon", "organism_id"],
+    "columns_renaming_map": {
+      "sample": "batch",
+      "pctmt": "percentMito"
+    }
+  },
+  "feature_metadata": {
+    "metadata_keys": {
+      "var": "metadata"
+    }
+  },
+  "cell_expression": {
+    "data_class": "Single-cell transcriptomics"
+  }
+}
+```
+
+- `columns_to_drop` — list of cell metadata columns to exclude from import.
+- `columns_renaming_map` — map of source column names to target names in ODM.
+
+## Linking resolution
+
+The transformation resolves the parent SLP entity for the created Cell Group automatically, in the order: Library → Preparation → Sample (it uses the first entity type it finds in the study).
+
+To link to a specific group by accession, set `cell_metadata.linking_group` explicitly:
+
+```json
+"cell_metadata": {
+  "linking_group": {
+    "library": "GSFXXXXXX"
+  }
+}
+```
+
+To link to all Preparation groups in the study without specifying accessions individually, set an empty value:
+
+```json
+"cell_metadata": {
+  "linking_group": {
+    "preparation": []
+  }
+}
+```
+
+For the full linking resolution rules, see `transformation-process-reference.md`.
+
+## Related
+
+- [How to run a transformation](../how-to-run-a-transformation.md)
+- [Configure metadata curation](configure-metadata-curation.md)
+- [Configuration reference](configuration-reference.md)

--- a/docs-rework/odm-api/contribute/transformations/single-cell/iterate-with-dry-runs.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/iterate-with-dry-runs.md
@@ -1,0 +1,69 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [145, 171]
+diataxis: how-to
+tab: odm-api
+task: task-104
+tickets:
+  - ODM-13233
+---
+
+# How to iterate on a configuration using dry runs
+
+This guide describes the recommended cycle for refining a transformation configuration before committing to a full run. Use this when an initial dry run reveals warnings or errors that require attention.
+
+## The iteration cycle
+
+```mermaid
+flowchart TD
+    A[Create configuration] --> B[Submit dry-run job]
+    B --> C[Review logs]
+    C --> D{Issues that<br/>need action?}
+    D -->|Yes| E[Update configuration<br/>PUT → new version]
+    E --> B
+    D -->|No| F[Submit full run<br/>dry_run: false]
+```
+
+## Step 1: Review the dry-run logs
+
+After a dry-run job completes, retrieve the logs:
+
+```
+POST /api/v1/transformations/jobs/{id}/logs
+```
+
+Look for:
+
+- **Configuration validation errors** — invalid field values or missing required keys.
+- **File structure report** — which metadata keys (`obs`, `var`, `obsm`, etc.) are present in your file. See `transformation-process-reference.md#15-file-structure-inspection`.
+- **Linking validation warnings** — whether all cell `batch` values map to existing SLP objects. See `transformation-process-reference.md#41-dry-run-exit`.
+- **Curation warnings** — columns flagged for automatic renaming or data type conversion.
+
+## Step 2: Update the configuration
+
+Update the configuration using:
+
+```
+PUT /api/v1/transformations/configurations/{id}
+```
+
+The request body follows the same structure as the original `POST`. Updating does not overwrite the configuration: the current state is archived as a previous version and the active version is incremented. The same `id` is reused, and earlier versions remain retrievable.
+
+## Step 3: Resubmit the dry run
+
+Resubmit the job against the same configuration `id`. Each dry run uses the latest version by default, so you can keep iterating on the same configuration without creating a new one for each attempt.
+
+## Step 4: Repeat until clean
+
+Repeat until the dry run completes without errors or warnings that require action.
+
+## Step 5: Submit the full run
+
+Submit the same job with `dry_run: false` in the request body.
+
+## Related
+
+- [Manage configurations](../manage-configurations.md) — full CRUD for configurations.
+- [Discover which biosample attributes are available](discover-biosample-attributes.md) — another use of dry-run mode.
+- `transformation-process-reference.md` — pipeline internals referenced in the logs.

--- a/docs-rework/odm-api/contribute/transformations/single-cell/process-10x-h5-files.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/process-10x-h5-files.md
@@ -1,0 +1,55 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [321, 348]
+diataxis: how-to
+tab: odm-api
+task: task-102
+---
+
+# How to process a 10x Genomics H5 file
+
+This guide explains how to ingest a 10x Genomics H5 file through the ODM single-cell transformation pipeline.
+
+## The only required change from H5AD
+
+Set `file_type` to `"h5"` instead of `"h5ad"`. Use the same H5AD key names (`obs`, `var`) in `metadata_keys` — the transformation converts the 10x H5 format to H5AD internally before applying unified processing.
+
+```json
+{
+  "file_type": "h5",
+  "cell_metadata": {
+    "metadata_keys": {
+      "obs": "metadata"
+    }
+  },
+  "feature_metadata": {
+    "metadata_keys": {
+      "var": "metadata"
+    }
+  },
+  "cell_expression": {
+    "data_class": "Single-cell transcriptomics"
+  }
+}
+```
+
+## Volume sizing
+
+When setting `volume_size` for a job using an H5 input file, allocate at least 4× the original attachment size (for example, a 5 GB file requires `volume_size` ≥ 20 GB). H5 inputs require additional scratch space because the transformation converts them to H5AD during processing.
+
+For H5AD inputs the guideline is ≥ 1.4× the original file size. See [Available images reference](../available-images-reference.md) for a summary.
+
+## Legacy 10x H5 support
+
+Legacy 10x Genomics H5 files (v<3) are supported only when the file contains a single genome. If the file includes multiple genomes, pre-process it to extract the genome of interest before running the transformation.
+
+## Prerequisites and workflow
+
+For the full job submission workflow, see [How to run a transformation](../how-to-run-a-transformation.md). For authentication prerequisites, see [Authentication and tokens](../../../getting-started/authentication-and-tokens.md).
+
+## Related
+
+- [About single-cell transformations](about-single-cell-transformations.md) — supported input formats overview.
+- [Available images reference](../available-images-reference.md) — volume sizing guidance.
+- [Configuration reference](configuration-reference.md)

--- a/docs-rework/odm-api/contribute/transformations/single-cell/single-cell-getting-started.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/single-cell-getting-started.md
@@ -1,0 +1,96 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/quickstart-sc.md
+    lines: [1, 90]
+diataxis: index
+tab: odm-api
+task: task-097
+---
+
+# Single-cell data in ODM: Getting started
+
+**Upload → Transform → Index → Search**
+
+This page walks you through the single-cell HDF5 workflow in ODM — uploading a file, running a transformation to produce indexed objects, confirming indexing, and exploring your data with search and analytics queries — and links to the notebooks for each stage.
+
+## Who this is for
+
+This guide is for users who want to try ODM's single-cell functionality on prepared datasets.
+
+## Prerequisites
+
+- ODM instance URL: `<HOST>`
+- API token: `<TOKEN>`. See [Authentication and tokens](../../../getting-started/authentication-and-tokens.md).
+- An environment set up to run Jupyter notebooks.
+
+---
+
+## Step 1: Upload and transform a single dataset
+
+The goal here is to walk through the full workflow on one HDF5 file and verify that analysis-ready objects appear in ODM.
+
+1. Create a study with an HDF5 file as an attachment.
+2. Run a transformation job to convert it into ODM-indexed single-cell objects.
+3. Verify that objects were created, linked, and indexed correctly.
+
+**Notebook:** [Single-Cell RNA-Seq: Data Transformation and Upload to ODM](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/notebooks/sc_transformations_demo.ipynb)
+
+
+This notebook covers: uploading the HDF5 file, creating a configuration, running a dry run, and checking job status and outputs.
+
+---
+
+## Step 2: Load curated public datasets
+
+The goal of this optional step is to populate ODM with a ready-made catalogue of curated public single-cell studies so you can test cross-study search without preparing your own data.
+
+1. Load the public dataset template.
+   - Template file: [public_studies_template_demo.json](https://bio-test-data.s3.us-east-1.amazonaws.com/demo_materials/templates/public_studies_template_demo.json)
+   - For template upload instructions, see [Create or update a template](../../../../api-libraries/odm-sdk/templates/create-or-update-a-template.md).
+2. Load the curated datasets (HDF5 attachments included).
+   - **Ready-to-run import commands:** [Curated public datasets](curated-public-datasets.md) — per-dataset copy-paste commands with placeholders for server, token, and template.
+
+---
+
+## Step 3: Transform curated datasets
+
+The goal is to transform the curated datasets into fully indexed objects with harmonised metadata.
+
+1. Using the transformation notebook from Step 1 as a reference, run the transformation for each curated dataset.
+2. Use the provided configurations to ensure consistent curation. You can skip the dry-run step, as the configurations are pre-tested.
+3. Monitor transformation jobs until all complete successfully.
+4. Confirm that the expected objects are present: Cell Group, Expression Group, and metadata objects.
+
+**Prepared configurations:** [Curated public datasets](curated-public-datasets.md#configuration-index) — the configuration to use for each dataset.
+
+---
+
+## Step 4: Confirm indexing
+
+Make sure all datasets are marked as indexed and ready to query.
+
+- Each transformed dataset shows the **Indexed** label in the ODM Metadata Editor.
+- All indexing tasks show **Done** status in Task Manager.
+
+> A completed transformation job does not mean data is immediately searchable. ODM automatically triggers indexing after ingestion, but data is only available for querying once indexing finishes.
+
+---
+
+## Step 5: Query and analyse single-cell data
+
+Use ODM's search and analytics notebooks to explore your indexed datasets.
+
+**Notebook:** [Single-Cell RNA-Seq: Cohort Selection and Data Retrieval](../../../../docs/user-guide/doc-odm-user-guide/doc-odm-user-guide/notebooks/sc_rnaseq_demo.ipynb)
+
+
+This notebook covers: cross-study search examples, filtering by curated attributes, example analytical queries, and result inspection.
+
+---
+
+## Next steps
+
+- [About single-cell transformations](about-single-cell-transformations.md) — conceptual overview of the transformation pipeline.
+- Per-task how-tos: [Ingest cell and expression data](ingest-cell-and-expression.md), [Create sample/library/preparation groups](create-sample-library-preparation-groups.md), [Update existing biosample metadata](update-existing-biosample-metadata.md), [Discover biosample attributes](discover-biosample-attributes.md).
+- [Configuration reference](configuration-reference.md) — full configuration schema.
+- [Transformation process reference](transformation-process-reference.md) — internal processing pipeline.
+- [API reference](../api-reference.md) — API endpoints.

--- a/docs-rework/odm-api/contribute/transformations/single-cell/transformation-process-reference.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/transformation-process-reference.md
@@ -1,0 +1,199 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/transformation-process-reference.md
+    lines: [1, 250]
+diataxis: reference
+tab: odm-api
+task: task-106
+tickets:
+  - ODM-13233
+---
+
+# Transformation process reference: Single-cell HDF5 transformation
+
+This reference describes the internal processing stages of the single-cell HDF5 transformation pipeline. It is intended for users who need to understand what the pipeline does at each stage — for example, to interpret logs, diagnose errors, or reason about the order of operations.
+
+For related documentation: [About single-cell transformations](about-single-cell-transformations.md) · [Configuration reference](configuration-reference.md) · [Getting started](single-cell-getting-started.md)
+
+---
+
+## Stage 1: Initial setup and file preparation
+
+### 1.1 Configuration loading and validation
+
+The pipeline reads the transformation configuration and validates all fields. The configuration version that was loaded is recorded in the log.
+
+Top-level key validation checks the presence and data types of `file_type`, `save_logs`, `biosample_metadata`, `cell_metadata`, `feature_metadata`, and `cell_expression`. If `file_type` is missing or contains an unsupported value (`"h5ad"` and `"h5"` are the only accepted values), the pipeline raises an error immediately.
+
+For all remaining sections, validation errors are accumulated and reported together at the end of the validation stage, so all issues are surfaced in a single run.
+
+Per-section validation covers: presence of required keys, data type correctness, key-value correctness for `metadata_keys` entries. `biosample_metadata` validation ensures that `library` and `preparation` are not both configured for simultaneous update. `cell_expression` validation resolves `number_format` to a dtype stored for downstream use. Unrecognised keys are logged as warnings and ignored.
+
+### 1.2 Attachment and study metadata retrieval
+
+The pipeline retrieves the accession and metadata of the input HDF5 attachment from ODM to determine the name to assign to the processed data objects and the study accession to which the resulting Cell Group and Expression Group will be associated.
+
+### 1.3 Linking group determination
+
+Before any file processing begins, the pipeline resolves the parent SLP entity (Sample, Library, or Preparation group) to link the Cell Group to. The resolution follows these rules in order:
+
+- **New SLP group creation deferred:** If `biosample_metadata` is present and any entity has `create_new_group: true`, linking resolution is deferred until after those new groups are created (Stage 4). Example:
+
+```json
+"biosample_metadata": {
+  "metadata_keys": { "obs": "metadata" },
+  "biosample_column_name": "sample_id",
+  "sample": { "create_new_group": true }
+}
+```
+
+- **Explicit `linking_group`:** If `cell_metadata.linking_group` is set, the specified entity type and accession(s) are used directly. An empty value resolves to all available group accessions of the specified entity type for the study. Examples:
+
+```json
+"cell_metadata": { "linking_group": { "sample": ["GSF000001"] } }
+```
+
+```json
+"cell_metadata": { "linking_group": { "preparation": [] } }
+```
+
+- **Auto-discovery:** If neither of the above applies, the pipeline fetches all SLP groups for the study and selects the first entity type that has at least one group, checking in the order Library → Preparation → Sample. All accessions of the selected type are used.
+
+If no SLP group can be found and no new group is being created, the pipeline raises an error.
+
+### 1.4 Temporary directory and file preparation
+
+A temporary directory is created for all intermediate files. The input HDF5 file is copied into this directory. If the input is `"h5"` (10x Genomics H5), it is converted to H5AD format so that subsequent stages can apply unified processing regardless of source format.
+
+### 1.5 File structure inspection
+
+The pipeline opens the H5AD file and logs its structure: top-level keys (groups), data types and shapes, and attribute names. This output is useful for verifying which metadata keys (`obs`, `var`, `obsm`, etc.) are present before extraction begins.
+
+---
+
+## Stage 2: Metadata extraction
+
+Each configured section (`biosample_metadata`, `cell_metadata`, `feature_metadata`) is processed independently.
+
+### 2.1 Configuration and input validation
+
+For each metadata section, the pipeline reads parameters and validates the presence of required keys and supported file types.
+
+### 2.2 Biosample metadata (`biosample_metadata` config)
+
+When `biosample_metadata` is present, the pipeline can export Sample, Library, or Preparation-level attributes derived from cell-level metadata. Only one of `library` or `preparation` may have `columns_to_export` set. Attributes exported to biosample metadata are automatically removed from cell metadata.
+
+**File reading and extraction:** The pipeline opens the H5AD file, reads the metadata from the group indicated by `metadata_keys`, and organises the table by `biosample_column_name`. Only attributes constant within a biosample and listed in `columns_to_export` are processed. The result is written to a TSV file in the temporary directory.
+
+**Discovery mode:** Activated only when `dry_run` is enabled, `biosample_metadata` is present, and no entity has `columns_to_export` defined. The pipeline logs the number of unique biosamples and the attributes constant within each biosample, then exits without writing a TSV. No ODM objects are created or modified.
+
+**Existing biosample metadata update:** When `columns_to_export` is configured for an entity but `create_new_group` is not set, the pipeline prepares an update to existing ODM objects. It fetches current metadata for the entity type, joins extracted metadata to existing metadata by the entity ID column (Sample Source ID, Library ID, or Preparation ID), and retains only attributes not already present in ODM. If any extracted ID does not match an existing ODM object, an error is raised listing the unmatched IDs.
+
+### 2.3 Cell and feature metadata extraction
+
+The pipeline opens the H5AD file and reads groups specified in `metadata_keys`:
+
+- Standard metadata (`"metadata"`) is loaded into a DataFrame.
+- Embeddings (`"embedding"`) are read as multidimensional arrays, serialised as comma-separated strings, and added as columns.
+- Pairwise data (`"pairwise"`) is read as pairwise matrices; for each matrix, the row mean is calculated and added as a column.
+
+### 2.4 Index handling and sanity checks
+
+- If the DataFrame is empty with neither columns nor an index, an error is raised.
+- An unnamed index is assigned the default name `_index`.
+- If the index name collides with an existing column name, it is renamed to avoid the conflict.
+- The index is extracted and appended as a column so that barcode or feature ID information is preserved.
+
+> If the cell barcode is in the index and the index has no name, the extracted column is named `_index`. To use a different name, rename it using `columns_renaming_map`.
+
+### 2.5 Column operations
+
+The following transformations are applied in order:
+
+1. Drop columns (`columns_to_drop`)
+2. Rename columns (`columns_renaming_map`)
+3. Curate values (`columns_to_curate_values`)
+4. Fill missing values (`columns_to_fill_missing_values`)
+5. Set constant values (`set_column_value`)
+
+After explicit column operations, attribute name standardisation is applied: column names are mapped to ODM canonical names where a mapping exists; non-standard names are converted to camelCase. Columns in `columns_to_preserve_name` are exempt. For the full mapping list, see `attribute-mapping-reference.md`.
+
+**Cell metadata additional steps:**
+
+- **Required column validation:** `barcode` (unique cell identifiers — duplicates or missing values cause an error) and `batch` (SLP linking identifiers — missing values cause an error).
+- **QC metric calculation:** number of counts, number of genes, percentage mitochondrial expression, and percentage ribosomal expression are added if not already present. Skipped when `add_qc_metrics: false` or when `dry_run: true`.
+
+**Feature metadata additional steps:**
+
+- **Gene ID mapping:** If gene names are absent and the `geneId` column is present, the pipeline infers the ID source (Ensembl or NCBI) and species, then adds a gene names column. The step can be skipped with `map_gene_ids_to_names: false`.
+
+### 2.6 Storing data
+
+The processed metadata DataFrame is written to the temporary directory as a TSV file.
+
+---
+
+## Stage 3: Cell expression extraction
+
+### 3.1 Configuration and input validation
+
+The pipeline reads expression parameters: `data_class`, `compression_level`, `chunk_size`, `max_buffer_size`, and `number_format`. Parameters not specified in the configuration are inferred from the data or set to sensible defaults.
+
+### 3.2 Expression matrix reading and validation
+
+The cell expression matrix is read from the HDF5 file. The pipeline validates that the matrix shape matches the number of cells and features determined in Stage 2.
+
+### 3.3 Expression data writing
+
+The expression data, enriched with feature metadata according to the configuration, is written to a Brotli-compressed file (`.br`) in the temporary directory.
+
+### 3.4 Expression metadata reading and writing
+
+Expression metadata from the source attachment is read and transformed according to `columns_to_drop`, `columns_renaming_map`, and `set_column_value`, unless `source_file_metadata` is `false`.
+
+The following statistics are always computed and appended regardless of the `source_file_metadata` flag:
+
+1. Total number of cells
+2. Total number of features
+3. Sparsity (%)
+4. Number of non-zero values
+5. Source file accession
+6. Source file name
+7. Configuration version
+
+---
+
+## Stage 4: Final steps and upload
+
+### 4.1 Dry run exit
+
+If `dry_run: true`, the pipeline performs linking validation and exits at this point. Expression matrix compression is skipped. Logs are reported and available in the API but not saved as attachments.
+
+Best-effort linking validation:
+
+- **Biosample coverage:** Unique values in the cell metadata `batch` column are compared against ID values of the resolved SLP groups. Unmatched values are logged as warnings.
+- **Duplicate IDs:** If the same ID value appears in more than one SLP object, a warning is logged.
+- **Group accession coverage:** Group accessions containing no biosample objects matching any cell `batch` value are logged as warnings.
+
+Validation mismatches are reported as warnings and do not abort the dry run.
+
+### 4.2 Upload to ODM
+
+#### 4.2.1 SLP groups
+
+If `biosample_metadata` is configured with at least one entity:
+
+- **New groups** (`create_new_group: true`): The corresponding TSV is uploaded as a new group via the entity-specific API endpoint with `template_id` applied if specified. Sample Groups are linked to the study; Library and Preparation Groups are linked to a Sample Group resolved by checking `linking_group.sample` in the entity's configuration, then a Sample Group created in the same run, then pre-fetched Sample Group accessions. The new group accession is stored for use in the cell group linking step.
+- **Existing groups** (`create_new_group` not set): For each row in the update TSV, the pipeline updates the corresponding object via the ODM PATCH API endpoint.
+
+#### 4.2.2 Cell Group upload
+
+The transformed cell metadata TSV is uploaded as a new Cell Group, linked to the parent SLP Groups determined in Stage 1.3 or Stage 4.2.1.
+
+#### 4.2.3 Expression Group upload
+
+The Brotli-compressed expression file and its metadata file are uploaded to create a new Expression Group, linked to the newly created Cell Group.
+
+#### 4.2.4 Log upload
+
+Transformation logs are uploaded as an attachment together with their metadata. The logs metadata file includes a `Configuration Version` field recording the configuration version the job ran against. This step is skipped if `save_logs: false`.

--- a/docs-rework/odm-api/contribute/transformations/single-cell/update-existing-biosample-metadata.md
+++ b/docs-rework/odm-api/contribute/transformations/single-cell/update-existing-biosample-metadata.md
@@ -1,0 +1,59 @@
+---
+sources:
+  - path: docs/user-guide/doc-odm-user-guide/how-to-sc-hdf5-transformations.md
+    lines: [273, 297]
+diataxis: how-to
+tab: odm-api
+task: task-100
+---
+
+# How to update existing biosample metadata
+
+This guide explains how to enrich existing Sample, Library, or Preparation (SLP) groups in ODM with attributes derived from your HDF5 file.
+
+## When to use this
+
+Use this guide when SLP groups already exist in ODM but are missing attributes that are present in the cell metadata of your HDF5 file.
+
+If no SLP groups exist yet, see [Create Sample, Library, or Preparation groups from an H5AD file](create-sample-library-preparation-groups.md) instead.
+
+## Prerequisites
+
+- An API token and Curator group membership. See [Authentication and tokens](../../../getting-started/authentication-and-tokens.md).
+- The HDF5 file uploaded as an attachment to your study.
+- Existing SLP groups in ODM.
+
+For the full job submission workflow, see [How to run a transformation](../how-to-run-a-transformation.md).
+
+## Configuration
+
+Configure `biosample_metadata` with `columns_to_export` for the target entity. Do **not** set `create_new_group: true` — that would create new groups instead of updating existing ones:
+
+```json
+{
+  "file_type": "h5ad",
+  "biosample_metadata": {
+    "metadata_keys": {
+      "obs": "metadata"
+    },
+    "biosample_column_name": "library_id",
+    "library": {
+      "columns_to_export": ["sequencing_platform", "library_strategy"]
+    }
+  }
+}
+```
+
+## Matching behaviour
+
+The transformation matches extracted rows to existing ODM objects using the entity ID column (Sample Source ID, Library ID, or Preparation ID). Only attributes that do not already exist in the ODM metadata are added. If any extracted ID does not match an existing ODM object, the transformation raises an error.
+
+## Recommendation
+
+Run a dry run first to catch ID mismatches before committing data. See [Manage configurations](../manage-configurations.md) for the recommended iteration loop.
+
+## Related
+
+- [Configure metadata curation](configure-metadata-curation.md)
+- [Iterate with dry runs](iterate-with-dry-runs.md)
+- [Configuration reference](configuration-reference.md)


### PR DESCRIPTION
The part of the user-docs restructuring project covering the Processors Controller transformation API end to end. 

API and behavioral claims were verified against ground truth (processors-controller-develop, transformation-images-develop) but still require a careful review, especially the reference pages.

All md files are designed to fit the diataxis framework which is going to be a new standard after the user docs restructure project is finished. 

Please note that these are not the final versions of the documents since some of the odm tickets related to this topic are still in progress. They may affect the content of these files. 